### PR TITLE
Feat/verify in guard validate in module

### DIFF
--- a/docs/classes/OtpGuard.md
+++ b/docs/classes/OtpGuard.md
@@ -34,32 +34,21 @@ A guard that verifies a one-time password (OTP) sent with a request.
 
 ### constructor
 
-• **new OtpGuard**(`otpService`, `config`): [`OtpGuard`](OtpGuard.md)
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `otpService` | [`OtpService`](OtpService.md) |
-| `config` | `Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\> |
+• **new OtpGuard**(): [`OtpGuard`](OtpGuard.md)
 
 #### Returns
 
 [`OtpGuard`](OtpGuard.md)
 
-#### Defined in
-
-[lib/guards/otp.guard.ts:21](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L21)
-
 ## Properties
 
 ### config
 
-• `Private` `Readonly` **config**: `Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\>
+• `Protected` `Readonly` **config**: `Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\>
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:24](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L24)
+[lib/guards/otp.guard.ts:25](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L25)
 
 ___
 
@@ -69,7 +58,7 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:22](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L22)
+[lib/guards/otp.guard.ts:22](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L22)
 
 ## Methods
 
@@ -95,7 +84,7 @@ CanActivate.canActivate
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:50](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L50)
+[lib/guards/otp.guard.ts:50](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L50)
 
 ___
 
@@ -119,7 +108,7 @@ The OTP.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:87](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L87)
+[lib/guards/otp.guard.ts:87](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L87)
 
 ___
 
@@ -143,7 +132,7 @@ The request.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:75](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L75)
+[lib/guards/otp.guard.ts:75](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L75)
 
 ___
 
@@ -167,7 +156,7 @@ The secret.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:66](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L66)
+[lib/guards/otp.guard.ts:66](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L66)
 
 ___
 
@@ -187,7 +176,7 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:135](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L135)
+[lib/guards/otp.guard.ts:135](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L135)
 
 ___
 
@@ -207,7 +196,7 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:129](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L129)
+[lib/guards/otp.guard.ts:129](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L129)
 
 ___
 
@@ -237,7 +226,7 @@ If the token is invalid and `shouldThrow` is true.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:112](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L112)
+[lib/guards/otp.guard.ts:112](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L112)
 
 ___
 
@@ -269,4 +258,4 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:27](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L27)
+[lib/guards/otp.guard.ts:27](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L27)

--- a/docs/classes/OtpGuard.md
+++ b/docs/classes/OtpGuard.md
@@ -16,6 +16,7 @@ A guard that verifies a one-time password (OTP) sent with a request.
 
 ### Properties
 
+- [config](OtpGuard.md#config)
 - [otpService](OtpGuard.md#otpservice)
 
 ### Methods
@@ -33,13 +34,14 @@ A guard that verifies a one-time password (OTP) sent with a request.
 
 ### constructor
 
-• **new OtpGuard**(`otpService`): [`OtpGuard`](OtpGuard.md)
+• **new OtpGuard**(`otpService`, `config`): [`OtpGuard`](OtpGuard.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `otpService` | [`OtpService`](OtpService.md) |
+| `config` | `Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\> |
 
 #### Returns
 
@@ -47,9 +49,19 @@ A guard that verifies a one-time password (OTP) sent with a request.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:19](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L19)
+[lib/guards/otp.guard.ts:21](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L21)
 
 ## Properties
+
+### config
+
+• `Private` `Readonly` **config**: `Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\>
+
+#### Defined in
+
+[lib/guards/otp.guard.ts:24](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L24)
+
+___
 
 ### otpService
 
@@ -57,7 +69,7 @@ A guard that verifies a one-time password (OTP) sent with a request.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:19](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L19)
+[lib/guards/otp.guard.ts:22](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L22)
 
 ## Methods
 
@@ -83,7 +95,7 @@ CanActivate.canActivate
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:44](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L44)
+[lib/guards/otp.guard.ts:50](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L50)
 
 ___
 
@@ -107,7 +119,7 @@ The OTP.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:106](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L106)
+[lib/guards/otp.guard.ts:87](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L87)
 
 ___
 
@@ -131,7 +143,7 @@ The request.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:94](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L94)
+[lib/guards/otp.guard.ts:75](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L75)
 
 ___
 
@@ -155,7 +167,7 @@ The secret.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:85](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L85)
+[lib/guards/otp.guard.ts:66](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L66)
 
 ___
 
@@ -175,7 +187,7 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:128](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L128)
+[lib/guards/otp.guard.ts:134](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L134)
 
 ___
 
@@ -195,7 +207,7 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:122](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L122)
+[lib/guards/otp.guard.ts:128](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L128)
 
 ___
 
@@ -225,7 +237,7 @@ If the token is invalid and `shouldThrow` is true.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:64](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L64)
+[lib/guards/otp.guard.ts:111](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L111)
 
 ___
 
@@ -257,4 +269,4 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:21](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L21)
+[lib/guards/otp.guard.ts:27](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L27)

--- a/docs/classes/OtpGuard.md
+++ b/docs/classes/OtpGuard.md
@@ -49,7 +49,7 @@ A guard that verifies a one-time password (OTP) sent with a request.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:21](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L21)
+[lib/guards/otp.guard.ts:21](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L21)
 
 ## Properties
 
@@ -59,7 +59,7 @@ A guard that verifies a one-time password (OTP) sent with a request.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:24](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L24)
+[lib/guards/otp.guard.ts:24](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L24)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:22](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L22)
+[lib/guards/otp.guard.ts:22](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L22)
 
 ## Methods
 
@@ -95,7 +95,7 @@ CanActivate.canActivate
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:50](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L50)
+[lib/guards/otp.guard.ts:50](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L50)
 
 ___
 
@@ -119,7 +119,7 @@ The OTP.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:87](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L87)
+[lib/guards/otp.guard.ts:87](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L87)
 
 ___
 
@@ -143,7 +143,7 @@ The request.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:75](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L75)
+[lib/guards/otp.guard.ts:75](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L75)
 
 ___
 
@@ -167,7 +167,7 @@ The secret.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:66](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L66)
+[lib/guards/otp.guard.ts:66](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L66)
 
 ___
 
@@ -187,7 +187,7 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:134](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L134)
+[lib/guards/otp.guard.ts:135](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L135)
 
 ___
 
@@ -207,7 +207,7 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:128](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L128)
+[lib/guards/otp.guard.ts:129](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L129)
 
 ___
 
@@ -237,7 +237,7 @@ If the token is invalid and `shouldThrow` is true.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:111](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L111)
+[lib/guards/otp.guard.ts:112](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L112)
 
 ___
 
@@ -269,4 +269,4 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:27](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/guards/otp.guard.ts#L27)
+[lib/guards/otp.guard.ts:27](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/guards/otp.guard.ts#L27)

--- a/docs/classes/OtpGuard.md
+++ b/docs/classes/OtpGuard.md
@@ -26,6 +26,7 @@ A guard that verifies a one-time password (OTP) sent with a request.
 - [getSecret](OtpGuard.md#getsecret)
 - [validateOTP](OtpGuard.md#validateotp)
 - [validateSecret](OtpGuard.md#validatesecret)
+- [verify](OtpGuard.md#verify)
 - [resolveSecretResolver](OtpGuard.md#resolvesecretresolver)
 
 ## Constructors
@@ -46,7 +47,7 @@ A guard that verifies a one-time password (OTP) sent with a request.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:14](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/guards/otp.guard.ts#L14)
+[lib/guards/otp.guard.ts:19](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L19)
 
 ## Properties
 
@@ -56,7 +57,7 @@ A guard that verifies a one-time password (OTP) sent with a request.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:14](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/guards/otp.guard.ts#L14)
+[lib/guards/otp.guard.ts:19](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L19)
 
 ## Methods
 
@@ -82,7 +83,7 @@ CanActivate.canActivate
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:39](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/guards/otp.guard.ts#L39)
+[lib/guards/otp.guard.ts:44](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L44)
 
 ___
 
@@ -106,7 +107,7 @@ The OTP.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:76](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/guards/otp.guard.ts#L76)
+[lib/guards/otp.guard.ts:106](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L106)
 
 ___
 
@@ -130,7 +131,7 @@ The request.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:64](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/guards/otp.guard.ts#L64)
+[lib/guards/otp.guard.ts:94](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L94)
 
 ___
 
@@ -154,7 +155,7 @@ The secret.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:55](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/guards/otp.guard.ts#L55)
+[lib/guards/otp.guard.ts:85](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L85)
 
 ___
 
@@ -174,7 +175,7 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:98](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/guards/otp.guard.ts#L98)
+[lib/guards/otp.guard.ts:128](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L128)
 
 ___
 
@@ -194,7 +195,37 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:92](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/guards/otp.guard.ts#L92)
+[lib/guards/otp.guard.ts:122](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L122)
+
+___
+
+### verify
+
+▸ **verify**(`token`, `secret`, `shouldThrow?`): `Promise`\<`boolean`\>
+
+Verify an OTP token against a secret.
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `token` | `string` | `undefined` | The OTP token to verify. |
+| `secret` | `string` | `undefined` | The secret used to verify the token. |
+| `shouldThrow` | `boolean` | `true` | Whether to throw an exception if the token is invalid. |
+
+#### Returns
+
+`Promise`\<`boolean`\>
+
+Whether the token is valid.
+
+**`Throws`**
+
+If the token is invalid and `shouldThrow` is true.
+
+#### Defined in
+
+[lib/guards/otp.guard.ts:64](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L64)
 
 ___
 
@@ -226,4 +257,4 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:16](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/guards/otp.guard.ts#L16)
+[lib/guards/otp.guard.ts:21](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/guards/otp.guard.ts#L21)

--- a/docs/classes/OtpGuard.md
+++ b/docs/classes/OtpGuard.md
@@ -48,7 +48,7 @@ A guard that verifies a one-time password (OTP) sent with a request.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:25](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L25)
+[lib/guards/otp.guard.ts:22](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/guards/otp.guard.ts#L22)
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:22](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L22)
+[lib/guards/otp.guard.ts:24](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/guards/otp.guard.ts#L24)
 
 ## Methods
 
@@ -84,7 +84,7 @@ CanActivate.canActivate
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:50](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L50)
+[lib/guards/otp.guard.ts:49](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/guards/otp.guard.ts#L49)
 
 ___
 
@@ -108,7 +108,7 @@ The OTP.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:87](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L87)
+[lib/guards/otp.guard.ts:89](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/guards/otp.guard.ts#L89)
 
 ___
 
@@ -132,7 +132,7 @@ The request.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:75](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L75)
+[lib/guards/otp.guard.ts:76](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/guards/otp.guard.ts#L76)
 
 ___
 
@@ -156,7 +156,7 @@ The secret.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:66](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L66)
+[lib/guards/otp.guard.ts:66](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/guards/otp.guard.ts#L66)
 
 ___
 
@@ -176,7 +176,7 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:135](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L135)
+[lib/guards/otp.guard.ts:137](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/guards/otp.guard.ts#L137)
 
 ___
 
@@ -196,7 +196,7 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:129](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L129)
+[lib/guards/otp.guard.ts:131](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/guards/otp.guard.ts#L131)
 
 ___
 
@@ -226,7 +226,7 @@ If the token is invalid and `shouldThrow` is true.
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:112](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L112)
+[lib/guards/otp.guard.ts:114](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/guards/otp.guard.ts#L114)
 
 ___
 
@@ -258,4 +258,4 @@ ___
 
 #### Defined in
 
-[lib/guards/otp.guard.ts:27](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/guards/otp.guard.ts#L27)
+[lib/guards/otp.guard.ts:26](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/guards/otp.guard.ts#L26)

--- a/docs/classes/OtpModule.md
+++ b/docs/classes/OtpModule.md
@@ -46,7 +46,7 @@ Registers the OTP module.
 
 #### Defined in
 
-[lib/otp.module.ts:20](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/otp.module.ts#L20)
+[lib/otp.module.ts:20](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/otp.module.ts#L20)
 
 ___
 
@@ -68,7 +68,7 @@ Registers the OTP module asynchronously.
 
 #### Defined in
 
-[lib/otp.module.ts:38](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/otp.module.ts#L38)
+[lib/otp.module.ts:38](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/otp.module.ts#L38)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[lib/otp.module.ts:60](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/otp.module.ts#L60)
+[lib/otp.module.ts:60](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/otp.module.ts#L60)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 #### Defined in
 
-[lib/otp.module.ts:113](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/otp.module.ts#L113)
+[lib/otp.module.ts:113](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/otp.module.ts#L113)
 
 ___
 
@@ -128,4 +128,4 @@ ___
 
 #### Defined in
 
-[lib/otp.module.ts:66](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/otp.module.ts#L66)
+[lib/otp.module.ts:66](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/otp.module.ts#L66)

--- a/docs/classes/OtpModule.md
+++ b/docs/classes/OtpModule.md
@@ -43,7 +43,7 @@ Registers the OTP module.
 
 #### Defined in
 
-[lib/otp.module.ts:13](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/otp.module.ts#L13)
+[lib/otp.module.ts:13](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/otp.module.ts#L13)
 
 ___
 
@@ -65,4 +65,4 @@ Registers the OTP module asynchronously.
 
 #### Defined in
 
-[lib/otp.module.ts:31](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/otp.module.ts#L31)
+[lib/otp.module.ts:31](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/otp.module.ts#L31)

--- a/docs/classes/OtpModule.md
+++ b/docs/classes/OtpModule.md
@@ -43,7 +43,7 @@ Registers the OTP module.
 
 #### Defined in
 
-[lib/otp.module.ts:13](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/otp.module.ts#L13)
+[lib/otp.module.ts:13](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/otp.module.ts#L13)
 
 ___
 
@@ -65,4 +65,4 @@ Registers the OTP module asynchronously.
 
 #### Defined in
 
-[lib/otp.module.ts:31](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/otp.module.ts#L31)
+[lib/otp.module.ts:31](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/otp.module.ts#L31)

--- a/docs/classes/OtpModule.md
+++ b/docs/classes/OtpModule.md
@@ -12,9 +12,6 @@
 
 - [register](OtpModule.md#register)
 - [registerAsync](OtpModule.md#registerasync)
-- [resolveConfig](OtpModule.md#resolveconfig)
-- [setDefaultOpts](OtpModule.md#setdefaultopts)
-- [validateOpts](OtpModule.md#validateopts)
 
 ## Constructors
 
@@ -46,7 +43,7 @@ Registers the OTP module.
 
 #### Defined in
 
-[lib/otp.module.ts:20](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/otp.module.ts#L20)
+[lib/otp.module.ts:13](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/otp.module.ts#L13)
 
 ___
 
@@ -68,64 +65,4 @@ Registers the OTP module asynchronously.
 
 #### Defined in
 
-[lib/otp.module.ts:38](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/otp.module.ts#L38)
-
-___
-
-### resolveConfig
-
-▸ **resolveConfig**(`config`): `Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\>
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `config` | [`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md) |
-
-#### Returns
-
-`Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\>
-
-#### Defined in
-
-[lib/otp.module.ts:60](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/otp.module.ts#L60)
-
-___
-
-### setDefaultOpts
-
-▸ **setDefaultOpts**(`config`): `Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\>
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `config` | [`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md) |
-
-#### Returns
-
-`Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\>
-
-#### Defined in
-
-[lib/otp.module.ts:113](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/otp.module.ts#L113)
-
-___
-
-### validateOpts
-
-▸ **validateOpts**(`config`): [`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `config` | [`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md) |
-
-#### Returns
-
-[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)
-
-#### Defined in
-
-[lib/otp.module.ts:66](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/otp.module.ts#L66)
+[lib/otp.module.ts:31](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/otp.module.ts#L31)

--- a/docs/classes/OtpModule.md
+++ b/docs/classes/OtpModule.md
@@ -12,6 +12,9 @@
 
 - [register](OtpModule.md#register)
 - [registerAsync](OtpModule.md#registerasync)
+- [resolveConfig](OtpModule.md#resolveconfig)
+- [setDefaultOpts](OtpModule.md#setdefaultopts)
+- [validateOpts](OtpModule.md#validateopts)
 
 ## Constructors
 
@@ -43,7 +46,7 @@ Registers the OTP module.
 
 #### Defined in
 
-[lib/otp.module.ts:12](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/otp.module.ts#L12)
+[lib/otp.module.ts:20](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/otp.module.ts#L20)
 
 ___
 
@@ -65,4 +68,64 @@ Registers the OTP module asynchronously.
 
 #### Defined in
 
-[lib/otp.module.ts:30](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/otp.module.ts#L30)
+[lib/otp.module.ts:38](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/otp.module.ts#L38)
+
+___
+
+### resolveConfig
+
+▸ **resolveConfig**(`config`): `Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `config` | [`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md) |
+
+#### Returns
+
+`Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\>
+
+#### Defined in
+
+[lib/otp.module.ts:60](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/otp.module.ts#L60)
+
+___
+
+### setDefaultOpts
+
+▸ **setDefaultOpts**(`config`): `Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `config` | [`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md) |
+
+#### Returns
+
+`Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\>
+
+#### Defined in
+
+[lib/otp.module.ts:113](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/otp.module.ts#L113)
+
+___
+
+### validateOpts
+
+▸ **validateOpts**(`config`): [`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `config` | [`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md) |
+
+#### Returns
+
+[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)
+
+#### Defined in
+
+[lib/otp.module.ts:66](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/otp.module.ts#L66)

--- a/docs/classes/OtpService.md
+++ b/docs/classes/OtpService.md
@@ -39,7 +39,7 @@
 
 #### Defined in
 
-[lib/services/otp.service.ts:11](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L11)
+[lib/services/otp.service.ts:11](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L11)
 
 ## Properties
 
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[lib/services/otp.service.ts:12](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L12)
+[lib/services/otp.service.ts:12](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L12)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[lib/services/otp.service.ts:9](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L9)
+[lib/services/otp.service.ts:9](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L9)
 
 ## Methods
 
@@ -83,7 +83,7 @@ The generated TOTP object.
 
 #### Defined in
 
-[lib/services/otp.service.ts:55](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L55)
+[lib/services/otp.service.ts:55](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L55)
 
 ___
 
@@ -107,7 +107,7 @@ Link for pairing with authenticator application.
 
 #### Defined in
 
-[lib/services/otp.service.ts:44](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L44)
+[lib/services/otp.service.ts:44](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L44)
 
 ___
 
@@ -131,7 +131,7 @@ A promise that resolves to the data URL of the QR code.
 
 #### Defined in
 
-[lib/services/otp.service.ts:68](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L68)
+[lib/services/otp.service.ts:68](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L68)
 
 ___
 
@@ -155,7 +155,7 @@ A promise that resolves to the string representation of the QR code.
 
 #### Defined in
 
-[lib/services/otp.service.ts:85](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L85)
+[lib/services/otp.service.ts:85](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L85)
 
 ___
 
@@ -179,4 +179,4 @@ The generated secret.
 
 #### Defined in
 
-[lib/services/otp.service.ts:21](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L21)
+[lib/services/otp.service.ts:21](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L21)

--- a/docs/classes/OtpService.md
+++ b/docs/classes/OtpService.md
@@ -2,10 +2,6 @@
 
 # Class: OtpService
 
-## Implements
-
-- `OnModuleInit`
-
 ## Table of contents
 
 ### Constructors
@@ -24,14 +20,10 @@
 ### Methods
 
 - [getTOTP](OtpService.md#gettotp)
-- [onModuleInit](OtpService.md#onmoduleinit)
 - [pair](OtpService.md#pair)
 - [qrDataURL](OtpService.md#qrdataurl)
 - [qrString](OtpService.md#qrstring)
 - [secret](OtpService.md#secret)
-- [setDefaultOpts](OtpService.md#setdefaultopts)
-- [validateOpts](OtpService.md#validateopts)
-- [verify](OtpService.md#verify)
 
 ## Constructors
 
@@ -51,7 +43,7 @@
 
 #### Defined in
 
-[lib/otp.service.ts:26](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/otp.service.ts#L26)
+[lib/services/otp.service.ts:26](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L26)
 
 ## Properties
 
@@ -61,7 +53,7 @@
 
 #### Defined in
 
-[lib/otp.service.ts:26](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/otp.service.ts#L26)
+[lib/services/otp.service.ts:26](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L26)
 
 ___
 
@@ -71,7 +63,7 @@ ___
 
 #### Defined in
 
-[lib/otp.service.ts:24](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/otp.service.ts#L24)
+[lib/services/otp.service.ts:24](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L24)
 
 ## Accessors
 
@@ -85,7 +77,7 @@ ___
 
 #### Defined in
 
-[lib/otp.service.ts:28](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/otp.service.ts#L28)
+[lib/services/otp.service.ts:28](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L28)
 
 ## Methods
 
@@ -109,25 +101,7 @@ The generated TOTP object.
 
 #### Defined in
 
-[lib/otp.service.ts:77](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/otp.service.ts#L77)
-
-___
-
-### onModuleInit
-
-▸ **onModuleInit**(): `void`
-
-#### Returns
-
-`void`
-
-#### Implementation of
-
-OnModuleInit.onModuleInit
-
-#### Defined in
-
-[lib/otp.service.ts:32](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/otp.service.ts#L32)
+[lib/services/otp.service.ts:72](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L72)
 
 ___
 
@@ -151,7 +125,7 @@ Link for pairing with authenticator application.
 
 #### Defined in
 
-[lib/otp.service.ts:66](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/otp.service.ts#L66)
+[lib/services/otp.service.ts:61](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L61)
 
 ___
 
@@ -175,7 +149,7 @@ A promise that resolves to the data URL of the QR code.
 
 #### Defined in
 
-[lib/otp.service.ts:115](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/otp.service.ts#L115)
+[lib/services/otp.service.ts:85](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L85)
 
 ___
 
@@ -199,7 +173,7 @@ A promise that resolves to the string representation of the QR code.
 
 #### Defined in
 
-[lib/otp.service.ts:132](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/otp.service.ts#L132)
+[lib/services/otp.service.ts:102](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L102)
 
 ___
 
@@ -223,62 +197,4 @@ The generated secret.
 
 #### Defined in
 
-[lib/otp.service.ts:43](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/otp.service.ts#L43)
-
-___
-
-### setDefaultOpts
-
-▸ **setDefaultOpts**(): `void`
-
-#### Returns
-
-`void`
-
-#### Defined in
-
-[lib/otp.service.ts:192](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/otp.service.ts#L192)
-
-___
-
-### validateOpts
-
-▸ **validateOpts**(): `void`
-
-#### Returns
-
-`void`
-
-#### Defined in
-
-[lib/otp.service.ts:143](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/otp.service.ts#L143)
-
-___
-
-### verify
-
-▸ **verify**(`token`, `secret`, `shouldThrow?`): `Promise`\<`boolean`\>
-
-Verify an OTP token against a secret.
-
-#### Parameters
-
-| Name | Type | Default value | Description |
-| :------ | :------ | :------ | :------ |
-| `token` | `string` | `undefined` | The OTP token to verify. |
-| `secret` | `string` | `undefined` | The secret used to verify the token. |
-| `shouldThrow` | `boolean` | `true` | Whether to throw an exception if the token is invalid. |
-
-#### Returns
-
-`Promise`\<`boolean`\>
-
-Whether the token is valid.
-
-**`Throws`**
-
-If the token is invalid and `shouldThrow` is true.
-
-#### Defined in
-
-[lib/otp.service.ts:92](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/otp.service.ts#L92)
+[lib/services/otp.service.ts:38](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L38)

--- a/docs/classes/OtpService.md
+++ b/docs/classes/OtpService.md
@@ -39,7 +39,7 @@
 
 #### Defined in
 
-[lib/services/otp.service.ts:11](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L11)
+[lib/services/otp.service.ts:11](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L11)
 
 ## Properties
 
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[lib/services/otp.service.ts:12](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L12)
+[lib/services/otp.service.ts:12](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L12)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[lib/services/otp.service.ts:9](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L9)
+[lib/services/otp.service.ts:9](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L9)
 
 ## Methods
 
@@ -83,7 +83,7 @@ The generated TOTP object.
 
 #### Defined in
 
-[lib/services/otp.service.ts:55](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L55)
+[lib/services/otp.service.ts:55](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L55)
 
 ___
 
@@ -107,7 +107,7 @@ Link for pairing with authenticator application.
 
 #### Defined in
 
-[lib/services/otp.service.ts:44](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L44)
+[lib/services/otp.service.ts:44](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L44)
 
 ___
 
@@ -131,7 +131,7 @@ A promise that resolves to the data URL of the QR code.
 
 #### Defined in
 
-[lib/services/otp.service.ts:68](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L68)
+[lib/services/otp.service.ts:68](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L68)
 
 ___
 
@@ -155,7 +155,7 @@ A promise that resolves to the string representation of the QR code.
 
 #### Defined in
 
-[lib/services/otp.service.ts:85](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L85)
+[lib/services/otp.service.ts:85](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L85)
 
 ___
 
@@ -179,4 +179,4 @@ The generated secret.
 
 #### Defined in
 
-[lib/services/otp.service.ts:21](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L21)
+[lib/services/otp.service.ts:21](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/services/otp.service.ts#L21)

--- a/docs/classes/OtpService.md
+++ b/docs/classes/OtpService.md
@@ -10,12 +10,8 @@
 
 ### Properties
 
-- [\_config](OtpService.md#_config)
-- [logger](OtpService.md#logger)
-
-### Accessors
-
 - [config](OtpService.md#config)
+- [logger](OtpService.md#logger)
 
 ### Methods
 
@@ -29,13 +25,13 @@
 
 ### constructor
 
-• **new OtpService**(`_config`): [`OtpService`](OtpService.md)
+• **new OtpService**(`config`): [`OtpService`](OtpService.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `_config` | [`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md) |
+| `config` | `Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\> |
 
 #### Returns
 
@@ -43,17 +39,17 @@
 
 #### Defined in
 
-[lib/services/otp.service.ts:26](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L26)
+[lib/services/otp.service.ts:11](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L11)
 
 ## Properties
 
-### \_config
+### config
 
-• `Private` **\_config**: [`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)
+• `Private` **config**: `Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\>
 
 #### Defined in
 
-[lib/services/otp.service.ts:26](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L26)
+[lib/services/otp.service.ts:12](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L12)
 
 ___
 
@@ -63,21 +59,7 @@ ___
 
 #### Defined in
 
-[lib/services/otp.service.ts:24](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L24)
-
-## Accessors
-
-### config
-
-• `get` **config**(): `Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\>
-
-#### Returns
-
-`Required`\<[`IOtpModuleOptions`](../interfaces/IOtpModuleOptions.md)\>
-
-#### Defined in
-
-[lib/services/otp.service.ts:28](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L28)
+[lib/services/otp.service.ts:9](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L9)
 
 ## Methods
 
@@ -101,7 +83,7 @@ The generated TOTP object.
 
 #### Defined in
 
-[lib/services/otp.service.ts:72](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L72)
+[lib/services/otp.service.ts:55](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L55)
 
 ___
 
@@ -125,7 +107,7 @@ Link for pairing with authenticator application.
 
 #### Defined in
 
-[lib/services/otp.service.ts:61](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L61)
+[lib/services/otp.service.ts:44](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L44)
 
 ___
 
@@ -149,7 +131,7 @@ A promise that resolves to the data URL of the QR code.
 
 #### Defined in
 
-[lib/services/otp.service.ts:85](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L85)
+[lib/services/otp.service.ts:68](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L68)
 
 ___
 
@@ -173,7 +155,7 @@ A promise that resolves to the string representation of the QR code.
 
 #### Defined in
 
-[lib/services/otp.service.ts:102](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L102)
+[lib/services/otp.service.ts:85](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L85)
 
 ___
 
@@ -197,4 +179,4 @@ The generated secret.
 
 #### Defined in
 
-[lib/services/otp.service.ts:38](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/services/otp.service.ts#L38)
+[lib/services/otp.service.ts:21](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/services/otp.service.ts#L21)

--- a/docs/classes/OtpService.md
+++ b/docs/classes/OtpService.md
@@ -39,7 +39,7 @@
 
 #### Defined in
 
-[lib/services/otp.service.ts:11](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L11)
+[lib/services/otp.service.ts:11](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/services/otp.service.ts#L11)
 
 ## Properties
 
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[lib/services/otp.service.ts:12](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L12)
+[lib/services/otp.service.ts:12](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/services/otp.service.ts#L12)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[lib/services/otp.service.ts:9](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L9)
+[lib/services/otp.service.ts:9](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/services/otp.service.ts#L9)
 
 ## Methods
 
@@ -83,7 +83,7 @@ The generated TOTP object.
 
 #### Defined in
 
-[lib/services/otp.service.ts:55](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L55)
+[lib/services/otp.service.ts:55](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/services/otp.service.ts#L55)
 
 ___
 
@@ -107,7 +107,7 @@ Link for pairing with authenticator application.
 
 #### Defined in
 
-[lib/services/otp.service.ts:44](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L44)
+[lib/services/otp.service.ts:44](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/services/otp.service.ts#L44)
 
 ___
 
@@ -131,7 +131,7 @@ A promise that resolves to the data URL of the QR code.
 
 #### Defined in
 
-[lib/services/otp.service.ts:68](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L68)
+[lib/services/otp.service.ts:68](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/services/otp.service.ts#L68)
 
 ___
 
@@ -155,7 +155,7 @@ A promise that resolves to the string representation of the QR code.
 
 #### Defined in
 
-[lib/services/otp.service.ts:85](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L85)
+[lib/services/otp.service.ts:85](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/services/otp.service.ts#L85)
 
 ___
 
@@ -179,4 +179,4 @@ The generated secret.
 
 #### Defined in
 
-[lib/services/otp.service.ts:21](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/services/otp.service.ts#L21)
+[lib/services/otp.service.ts:21](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/services/otp.service.ts#L21)

--- a/docs/interfaces/IOtpModuleAsyncOptions.md
+++ b/docs/interfaces/IOtpModuleAsyncOptions.md
@@ -31,7 +31,7 @@ Additional providers to register with the OTP module.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:124](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L124)
+[lib/interfaces/otp.interface.ts:124](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L124)
 
 ___
 
@@ -60,7 +60,7 @@ Optional dependencies to inject into the OTP module.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:119](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L119)
+[lib/interfaces/otp.interface.ts:119](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L119)
 
 ___
 
@@ -72,7 +72,7 @@ A class that implements the OTP module options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:107](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L107)
+[lib/interfaces/otp.interface.ts:107](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L107)
 
 ___
 
@@ -84,7 +84,7 @@ An existing instance of the OTP module options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:102](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L102)
+[lib/interfaces/otp.interface.ts:102](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L102)
 
 ___
 
@@ -112,4 +112,4 @@ A factory function that returns the OTP module options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:112](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L112)
+[lib/interfaces/otp.interface.ts:112](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L112)

--- a/docs/interfaces/IOtpModuleAsyncOptions.md
+++ b/docs/interfaces/IOtpModuleAsyncOptions.md
@@ -31,7 +31,7 @@ Additional providers to register with the OTP module.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:114](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L114)
+[lib/interfaces/otp.interface.ts:114](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L114)
 
 ___
 
@@ -60,7 +60,7 @@ Optional dependencies to inject into the OTP module.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:109](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L109)
+[lib/interfaces/otp.interface.ts:109](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L109)
 
 ___
 
@@ -72,7 +72,7 @@ A class that implements the OTP module options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:97](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L97)
+[lib/interfaces/otp.interface.ts:97](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L97)
 
 ___
 
@@ -84,7 +84,7 @@ An existing instance of the OTP module options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:92](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L92)
+[lib/interfaces/otp.interface.ts:92](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L92)
 
 ___
 
@@ -112,4 +112,4 @@ A factory function that returns the OTP module options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:102](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L102)
+[lib/interfaces/otp.interface.ts:102](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L102)

--- a/docs/interfaces/IOtpModuleAsyncOptions.md
+++ b/docs/interfaces/IOtpModuleAsyncOptions.md
@@ -31,7 +31,7 @@ Additional providers to register with the OTP module.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:124](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L124)
+[lib/interfaces/otp.interface.ts:124](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L124)
 
 ___
 
@@ -60,7 +60,7 @@ Optional dependencies to inject into the OTP module.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:119](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L119)
+[lib/interfaces/otp.interface.ts:119](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L119)
 
 ___
 
@@ -72,7 +72,7 @@ A class that implements the OTP module options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:107](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L107)
+[lib/interfaces/otp.interface.ts:107](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L107)
 
 ___
 
@@ -84,7 +84,7 @@ An existing instance of the OTP module options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:102](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L102)
+[lib/interfaces/otp.interface.ts:102](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L102)
 
 ___
 
@@ -112,4 +112,4 @@ A factory function that returns the OTP module options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:112](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L112)
+[lib/interfaces/otp.interface.ts:112](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L112)

--- a/docs/interfaces/IOtpModuleAsyncOptions.md
+++ b/docs/interfaces/IOtpModuleAsyncOptions.md
@@ -31,7 +31,7 @@ Additional providers to register with the OTP module.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:114](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L114)
+[lib/interfaces/otp.interface.ts:114](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L114)
 
 ___
 
@@ -60,7 +60,7 @@ Optional dependencies to inject into the OTP module.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:109](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L109)
+[lib/interfaces/otp.interface.ts:109](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L109)
 
 ___
 
@@ -72,7 +72,7 @@ A class that implements the OTP module options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:97](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L97)
+[lib/interfaces/otp.interface.ts:97](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L97)
 
 ___
 
@@ -84,7 +84,7 @@ An existing instance of the OTP module options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:92](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L92)
+[lib/interfaces/otp.interface.ts:92](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L92)
 
 ___
 
@@ -112,4 +112,4 @@ A factory function that returns the OTP module options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:102](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L102)
+[lib/interfaces/otp.interface.ts:102](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L102)

--- a/docs/interfaces/IOtpModuleAsyncOptions.md
+++ b/docs/interfaces/IOtpModuleAsyncOptions.md
@@ -31,7 +31,7 @@ Additional providers to register with the OTP module.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:114](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L114)
+[lib/interfaces/otp.interface.ts:124](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L124)
 
 ___
 
@@ -60,7 +60,7 @@ Optional dependencies to inject into the OTP module.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:109](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L109)
+[lib/interfaces/otp.interface.ts:119](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L119)
 
 ___
 
@@ -72,7 +72,7 @@ A class that implements the OTP module options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:97](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L97)
+[lib/interfaces/otp.interface.ts:107](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L107)
 
 ___
 
@@ -84,7 +84,7 @@ An existing instance of the OTP module options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:92](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L92)
+[lib/interfaces/otp.interface.ts:102](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L102)
 
 ___
 
@@ -112,4 +112,4 @@ A factory function that returns the OTP module options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:102](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L102)
+[lib/interfaces/otp.interface.ts:112](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L112)

--- a/docs/interfaces/IOtpModuleOptions.md
+++ b/docs/interfaces/IOtpModuleOptions.md
@@ -19,6 +19,8 @@ Options for the OTP module.
 - [requestResolver](IOtpModuleOptions.md#requestresolver)
 - [secretMethod](IOtpModuleOptions.md#secretmethod)
 - [secretResolver](IOtpModuleOptions.md#secretresolver)
+- [silent](IOtpModuleOptions.md#silent)
+- [skipValidation](IOtpModuleOptions.md#skipvalidation)
 - [window](IOtpModuleOptions.md#window)
 
 ## Properties
@@ -31,7 +33,7 @@ The algorithm to use for generating the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:41](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L41)
+[lib/interfaces/otp.interface.ts:51](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L51)
 
 ___
 
@@ -43,7 +45,7 @@ The number of digits in the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:46](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L46)
+[lib/interfaces/otp.interface.ts:56](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L56)
 
 ___
 
@@ -55,7 +57,7 @@ The header to use for the OTP in the request.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:56](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L56)
+[lib/interfaces/otp.interface.ts:66](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L66)
 
 ___
 
@@ -67,7 +69,7 @@ The issuer of the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:26](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L26)
+[lib/interfaces/otp.interface.ts:36](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L36)
 
 ___
 
@@ -79,7 +81,7 @@ Whether to include the issuer in the OTP label.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:36](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L36)
+[lib/interfaces/otp.interface.ts:46](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L46)
 
 ___
 
@@ -91,7 +93,7 @@ The label of the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:31](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L31)
+[lib/interfaces/otp.interface.ts:41](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L41)
 
 ___
 
@@ -119,7 +121,7 @@ A function that returns the OTP from the request.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:66](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L66)
+[lib/interfaces/otp.interface.ts:76](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L76)
 
 ___
 
@@ -131,7 +133,7 @@ The period, in seconds, for which the OTP is valid.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:51](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L51)
+[lib/interfaces/otp.interface.ts:61](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L61)
 
 ___
 
@@ -159,7 +161,7 @@ A function that returns the request from the execution context.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:71](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L71)
+[lib/interfaces/otp.interface.ts:81](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L81)
 
 ___
 
@@ -171,7 +173,7 @@ Method used for transforming the secret into TOTP-compatible format. Default: 'f
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:81](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L81)
+[lib/interfaces/otp.interface.ts:91](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L91)
 
 ___
 
@@ -183,7 +185,31 @@ A function that returns the secret to use for generating the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:61](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L61)
+[lib/interfaces/otp.interface.ts:71](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L71)
+
+___
+
+### silent
+
+• `Optional` **silent**: `boolean`
+
+Flag to disable logger warnings on module config resolution.
+
+#### Defined in
+
+[lib/interfaces/otp.interface.ts:31](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L31)
+
+___
+
+### skipValidation
+
+• `Optional` **skipValidation**: `boolean`
+
+Flag to disable validation of module config options.
+
+#### Defined in
+
+[lib/interfaces/otp.interface.ts:26](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L26)
 
 ___
 
@@ -195,4 +221,4 @@ Window of counter values to test.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:76](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L76)
+[lib/interfaces/otp.interface.ts:86](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L86)

--- a/docs/interfaces/IOtpModuleOptions.md
+++ b/docs/interfaces/IOtpModuleOptions.md
@@ -33,7 +33,7 @@ The algorithm to use for generating the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:51](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L51)
+[lib/interfaces/otp.interface.ts:51](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L51)
 
 ___
 
@@ -45,7 +45,7 @@ The number of digits in the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:56](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L56)
+[lib/interfaces/otp.interface.ts:56](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L56)
 
 ___
 
@@ -57,7 +57,7 @@ The header to use for the OTP in the request.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:66](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L66)
+[lib/interfaces/otp.interface.ts:66](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L66)
 
 ___
 
@@ -69,7 +69,7 @@ The issuer of the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:36](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L36)
+[lib/interfaces/otp.interface.ts:36](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L36)
 
 ___
 
@@ -81,7 +81,7 @@ Whether to include the issuer in the OTP label.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:46](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L46)
+[lib/interfaces/otp.interface.ts:46](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L46)
 
 ___
 
@@ -93,7 +93,7 @@ The label of the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:41](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L41)
+[lib/interfaces/otp.interface.ts:41](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L41)
 
 ___
 
@@ -121,7 +121,7 @@ A function that returns the OTP from the request.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:76](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L76)
+[lib/interfaces/otp.interface.ts:76](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L76)
 
 ___
 
@@ -133,7 +133,7 @@ The period, in seconds, for which the OTP is valid.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:61](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L61)
+[lib/interfaces/otp.interface.ts:61](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L61)
 
 ___
 
@@ -161,7 +161,7 @@ A function that returns the request from the execution context.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:81](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L81)
+[lib/interfaces/otp.interface.ts:81](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L81)
 
 ___
 
@@ -173,7 +173,7 @@ Method used for transforming the secret into TOTP-compatible format. Default: 'f
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:91](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L91)
+[lib/interfaces/otp.interface.ts:91](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L91)
 
 ___
 
@@ -185,7 +185,7 @@ A function that returns the secret to use for generating the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:71](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L71)
+[lib/interfaces/otp.interface.ts:71](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L71)
 
 ___
 
@@ -197,7 +197,7 @@ Flag to disable logger warnings on module config resolution.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:31](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L31)
+[lib/interfaces/otp.interface.ts:31](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L31)
 
 ___
 
@@ -209,7 +209,7 @@ Flag to disable validation of module config options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:26](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L26)
+[lib/interfaces/otp.interface.ts:26](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L26)
 
 ___
 
@@ -221,4 +221,4 @@ Window of counter values to test.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:86](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L86)
+[lib/interfaces/otp.interface.ts:86](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L86)

--- a/docs/interfaces/IOtpModuleOptions.md
+++ b/docs/interfaces/IOtpModuleOptions.md
@@ -33,7 +33,7 @@ The algorithm to use for generating the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:51](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L51)
+[lib/interfaces/otp.interface.ts:51](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L51)
 
 ___
 
@@ -45,7 +45,7 @@ The number of digits in the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:56](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L56)
+[lib/interfaces/otp.interface.ts:56](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L56)
 
 ___
 
@@ -57,7 +57,7 @@ The header to use for the OTP in the request.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:66](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L66)
+[lib/interfaces/otp.interface.ts:66](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L66)
 
 ___
 
@@ -69,7 +69,7 @@ The issuer of the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:36](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L36)
+[lib/interfaces/otp.interface.ts:36](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L36)
 
 ___
 
@@ -81,7 +81,7 @@ Whether to include the issuer in the OTP label.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:46](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L46)
+[lib/interfaces/otp.interface.ts:46](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L46)
 
 ___
 
@@ -93,7 +93,7 @@ The label of the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:41](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L41)
+[lib/interfaces/otp.interface.ts:41](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L41)
 
 ___
 
@@ -121,7 +121,7 @@ A function that returns the OTP from the request.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:76](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L76)
+[lib/interfaces/otp.interface.ts:76](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L76)
 
 ___
 
@@ -133,7 +133,7 @@ The period, in seconds, for which the OTP is valid.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:61](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L61)
+[lib/interfaces/otp.interface.ts:61](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L61)
 
 ___
 
@@ -161,7 +161,7 @@ A function that returns the request from the execution context.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:81](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L81)
+[lib/interfaces/otp.interface.ts:81](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L81)
 
 ___
 
@@ -173,7 +173,7 @@ Method used for transforming the secret into TOTP-compatible format. Default: 'f
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:91](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L91)
+[lib/interfaces/otp.interface.ts:91](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L91)
 
 ___
 
@@ -185,7 +185,7 @@ A function that returns the secret to use for generating the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:71](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L71)
+[lib/interfaces/otp.interface.ts:71](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L71)
 
 ___
 
@@ -197,7 +197,7 @@ Flag to disable logger warnings on module config resolution.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:31](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L31)
+[lib/interfaces/otp.interface.ts:31](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L31)
 
 ___
 
@@ -209,7 +209,7 @@ Flag to disable validation of module config options.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:26](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L26)
+[lib/interfaces/otp.interface.ts:26](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L26)
 
 ___
 
@@ -221,4 +221,4 @@ Window of counter values to test.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:86](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L86)
+[lib/interfaces/otp.interface.ts:86](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L86)

--- a/docs/interfaces/IOtpModuleOptions.md
+++ b/docs/interfaces/IOtpModuleOptions.md
@@ -31,7 +31,7 @@ The algorithm to use for generating the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:41](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L41)
+[lib/interfaces/otp.interface.ts:41](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L41)
 
 ___
 
@@ -43,7 +43,7 @@ The number of digits in the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:46](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L46)
+[lib/interfaces/otp.interface.ts:46](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L46)
 
 ___
 
@@ -55,7 +55,7 @@ The header to use for the OTP in the request.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:56](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L56)
+[lib/interfaces/otp.interface.ts:56](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L56)
 
 ___
 
@@ -67,7 +67,7 @@ The issuer of the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:26](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L26)
+[lib/interfaces/otp.interface.ts:26](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L26)
 
 ___
 
@@ -79,7 +79,7 @@ Whether to include the issuer in the OTP label.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:36](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L36)
+[lib/interfaces/otp.interface.ts:36](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L36)
 
 ___
 
@@ -91,7 +91,7 @@ The label of the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:31](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L31)
+[lib/interfaces/otp.interface.ts:31](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L31)
 
 ___
 
@@ -119,7 +119,7 @@ A function that returns the OTP from the request.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:66](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L66)
+[lib/interfaces/otp.interface.ts:66](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L66)
 
 ___
 
@@ -131,7 +131,7 @@ The period, in seconds, for which the OTP is valid.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:51](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L51)
+[lib/interfaces/otp.interface.ts:51](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L51)
 
 ___
 
@@ -159,7 +159,7 @@ A function that returns the request from the execution context.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:71](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L71)
+[lib/interfaces/otp.interface.ts:71](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L71)
 
 ___
 
@@ -171,7 +171,7 @@ Method used for transforming the secret into TOTP-compatible format. Default: 'f
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:81](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L81)
+[lib/interfaces/otp.interface.ts:81](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L81)
 
 ___
 
@@ -183,7 +183,7 @@ A function that returns the secret to use for generating the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:61](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L61)
+[lib/interfaces/otp.interface.ts:61](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L61)
 
 ___
 
@@ -195,4 +195,4 @@ Window of counter values to test.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:76](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L76)
+[lib/interfaces/otp.interface.ts:76](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L76)

--- a/docs/interfaces/IOtpModuleOptions.md
+++ b/docs/interfaces/IOtpModuleOptions.md
@@ -31,7 +31,7 @@ The algorithm to use for generating the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:41](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L41)
+[lib/interfaces/otp.interface.ts:41](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L41)
 
 ___
 
@@ -43,7 +43,7 @@ The number of digits in the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:46](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L46)
+[lib/interfaces/otp.interface.ts:46](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L46)
 
 ___
 
@@ -55,7 +55,7 @@ The header to use for the OTP in the request.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:56](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L56)
+[lib/interfaces/otp.interface.ts:56](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L56)
 
 ___
 
@@ -67,7 +67,7 @@ The issuer of the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:26](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L26)
+[lib/interfaces/otp.interface.ts:26](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L26)
 
 ___
 
@@ -79,7 +79,7 @@ Whether to include the issuer in the OTP label.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:36](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L36)
+[lib/interfaces/otp.interface.ts:36](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L36)
 
 ___
 
@@ -91,7 +91,7 @@ The label of the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:31](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L31)
+[lib/interfaces/otp.interface.ts:31](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L31)
 
 ___
 
@@ -119,7 +119,7 @@ A function that returns the OTP from the request.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:66](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L66)
+[lib/interfaces/otp.interface.ts:66](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L66)
 
 ___
 
@@ -131,7 +131,7 @@ The period, in seconds, for which the OTP is valid.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:51](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L51)
+[lib/interfaces/otp.interface.ts:51](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L51)
 
 ___
 
@@ -159,7 +159,7 @@ A function that returns the request from the execution context.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:71](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L71)
+[lib/interfaces/otp.interface.ts:71](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L71)
 
 ___
 
@@ -171,7 +171,7 @@ Method used for transforming the secret into TOTP-compatible format. Default: 'f
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:81](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L81)
+[lib/interfaces/otp.interface.ts:81](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L81)
 
 ___
 
@@ -183,7 +183,7 @@ A function that returns the secret to use for generating the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:61](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L61)
+[lib/interfaces/otp.interface.ts:61](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L61)
 
 ___
 
@@ -195,4 +195,4 @@ Window of counter values to test.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:76](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L76)
+[lib/interfaces/otp.interface.ts:76](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L76)

--- a/docs/interfaces/IOtpPairOpts.md
+++ b/docs/interfaces/IOtpPairOpts.md
@@ -20,4 +20,4 @@ The secret to use for generating the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:134](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L134)
+[lib/interfaces/otp.interface.ts:134](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L134)

--- a/docs/interfaces/IOtpPairOpts.md
+++ b/docs/interfaces/IOtpPairOpts.md
@@ -20,4 +20,4 @@ The secret to use for generating the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:134](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L134)
+[lib/interfaces/otp.interface.ts:134](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L134)

--- a/docs/interfaces/IOtpPairOpts.md
+++ b/docs/interfaces/IOtpPairOpts.md
@@ -20,4 +20,4 @@ The secret to use for generating the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:124](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L124)
+[lib/interfaces/otp.interface.ts:124](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L124)

--- a/docs/interfaces/IOtpPairOpts.md
+++ b/docs/interfaces/IOtpPairOpts.md
@@ -20,4 +20,4 @@ The secret to use for generating the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:124](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L124)
+[lib/interfaces/otp.interface.ts:124](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L124)

--- a/docs/interfaces/IOtpPairOpts.md
+++ b/docs/interfaces/IOtpPairOpts.md
@@ -20,4 +20,4 @@ The secret to use for generating the OTP.
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:124](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L124)
+[lib/interfaces/otp.interface.ts:134](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L134)

--- a/docs/interfaces/IOtpSecretResolver.md
+++ b/docs/interfaces/IOtpSecretResolver.md
@@ -30,4 +30,4 @@
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:12](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L12)
+[lib/interfaces/otp.interface.ts:12](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L12)

--- a/docs/interfaces/IOtpSecretResolver.md
+++ b/docs/interfaces/IOtpSecretResolver.md
@@ -30,4 +30,4 @@
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:12](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L12)
+[lib/interfaces/otp.interface.ts:12](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L12)

--- a/docs/interfaces/IOtpSecretResolver.md
+++ b/docs/interfaces/IOtpSecretResolver.md
@@ -30,4 +30,4 @@
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:12](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L12)
+[lib/interfaces/otp.interface.ts:12](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L12)

--- a/docs/interfaces/IOtpSecretResolver.md
+++ b/docs/interfaces/IOtpSecretResolver.md
@@ -30,4 +30,4 @@
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:12](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L12)
+[lib/interfaces/otp.interface.ts:12](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L12)

--- a/docs/interfaces/IOtpSecretResolver.md
+++ b/docs/interfaces/IOtpSecretResolver.md
@@ -30,4 +30,4 @@
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:12](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L12)
+[lib/interfaces/otp.interface.ts:12](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L12)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -29,4 +29,4 @@
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:15](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L15)
+[lib/interfaces/otp.interface.ts:15](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L15)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -29,4 +29,4 @@
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:15](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L15)
+[lib/interfaces/otp.interface.ts:15](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L15)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -29,4 +29,4 @@
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:15](https://github.com/mwognicki/nestjs-otp/blob/e6a60e8/lib/interfaces/otp.interface.ts#L15)
+[lib/interfaces/otp.interface.ts:15](https://github.com/mwognicki/nestjs-otp/blob/77280bc/lib/interfaces/otp.interface.ts#L15)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -29,4 +29,4 @@
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:15](https://github.com/mwognicki/nestjs-otp/blob/f9a2fb7/lib/interfaces/otp.interface.ts#L15)
+[lib/interfaces/otp.interface.ts:15](https://github.com/mwognicki/nestjs-otp/blob/158743c/lib/interfaces/otp.interface.ts#L15)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -29,4 +29,4 @@
 
 #### Defined in
 
-[lib/interfaces/otp.interface.ts:15](https://github.com/mwognicki/nestjs-otp/blob/60cf302/lib/interfaces/otp.interface.ts#L15)
+[lib/interfaces/otp.interface.ts:15](https://github.com/mwognicki/nestjs-otp/blob/eb7d539/lib/interfaces/otp.interface.ts#L15)

--- a/lib/__tests__/otp.guard.spec.ts
+++ b/lib/__tests__/otp.guard.spec.ts
@@ -1,296 +1,292 @@
-import { IOtpModuleOptions, IOtpSecretResolver } from '../interfaces';
-import { Test } from '@nestjs/testing';
-import { OtpModule } from '../otp.module';
-import { TestController } from './test-utils/test.controller';
+import {IOtpModuleOptions, IOtpSecretResolver} from '../interfaces';
+import {Test} from '@nestjs/testing';
+import {OtpModule} from '../otp.module';
+import {TestController} from './test-utils/test.controller';
 import request from 'supertest';
-import { Request } from 'express';
-import { OtpService } from '../services';
-import {
-  OTP_DEFAULT_HEADER,
-  OTP_MIN_SECURE_DIGITS,
-  OTP_MIN_SECURE_PERIOD,
-} from '../otp.constants';
-import { Logger } from '@nestjs/common';
+import {Request} from 'express';
+import {OtpService} from '../services';
+import {OTP_DEFAULT_HEADER, OTP_MIN_SECURE_DIGITS, OTP_MIN_SECURE_PERIOD,} from '../otp.constants';
+import {Logger} from '@nestjs/common';
 import * as OTPAuth from "otpauth";
 
 const setup = async (
-  config: Partial<IOtpModuleOptions>,
-  otpServiceMock?: any,
+    config: Partial<IOtpModuleOptions>,
+    otpServiceMock?: any,
 ) => {
-  const module = await Test.createTestingModule({
-    imports: [
-      OtpModule.register({ label: 'Label', issuer: 'Issuer', ...config }),
-    ],
-    providers: otpServiceMock
-      ? [
-          {
-            provide: OtpService,
-            useExisting: otpServiceMock,
-          },
-        ]
-      : [],
-    controllers: [TestController],
-  }).compile();
+    const module = await Test.createTestingModule({
+        imports: [
+            OtpModule.register({label: 'Label', issuer: 'Issuer', ...config}),
+        ],
+        providers: otpServiceMock
+            ? [
+                {
+                    provide: OtpService,
+                    useExisting: otpServiceMock,
+                },
+            ]
+            : [],
+        controllers: [TestController],
+    }).compile();
 
-  const app = module.createNestApplication();
-  return app.init();
+    const app = module.createNestApplication();
+    return app.init();
 };
 
 const createSecretResolver = (mock: Function) => {
-  return new (class implements IOtpSecretResolver {
-    resolve(request: Request) {
-      return mock(request);
-    }
-  })();
+    return new (class implements IOtpSecretResolver {
+        resolve(request: Request) {
+            return mock(request);
+        }
+    })();
 };
 
 describe('OtpModule', () => {
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  })
+    afterEach(() => {
+        jest.clearAllMocks();
+    })
 
-  describe('otp resolver', () => {
-    it('should get OTP from header', async () => {
-      let otpValidateMock;
-      const otpServiceMock = jest
-        .spyOn(OtpService.prototype, 'getTOTP')
-        .mockImplementation( () => {
-          const totp = new OTPAuth.TOTP({
-            secret: OTPAuth.Secret.fromUTF8('any'),
-          });
-          otpValidateMock = jest.spyOn(totp, 'validate').mockReturnValue(1)
-          return totp;
+    describe('otp resolver', () => {
+        it('should get OTP from header', async () => {
+            let otpValidateMock;
+            const otpServiceMock = jest
+                .spyOn(OtpService.prototype, 'getTOTP')
+                .mockImplementation(() => {
+                    const totp = new OTPAuth.TOTP({
+                        secret: OTPAuth.Secret.fromUTF8('any'),
+                    });
+                    otpValidateMock = jest.spyOn(totp, 'validate').mockReturnValue(1)
+                    return totp;
+                });
+
+            const secret = '654321', token = '123456';
+
+            const otp = await setup({
+                secretResolver: () => secret,
+            });
+
+            await request(otp.getHttpServer())
+                .get('/test')
+                .set('X-One-Time-Password', token)
+                .expect(200);
+
+            expect(otpValidateMock).toHaveBeenNthCalledWith(1, {token});
+            expect(otpServiceMock).toHaveBeenNthCalledWith(1, {secret});
+
+            otpServiceMock.mockRestore();
         });
 
-      const secret = '654321', token = '123456';
+        it('should get OTP from header when header name is custom (failed)', async () => {
+            const otpServiceMock = jest
+                .spyOn(OtpService.prototype, 'getTOTP')
+                .mockImplementation();
 
-      const otp = await setup({
-        secretResolver: () => secret,
-      });
+            const secret = '654321', token = '123456';
 
-      await request(otp.getHttpServer())
-        .get('/test')
-        .set('X-One-Time-Password', token)
-        .expect(200);
-
-      expect(otpValidateMock).toHaveBeenNthCalledWith(1, {token});
-      expect(otpServiceMock).toHaveBeenNthCalledWith(1, {secret});
-
-      otpServiceMock.mockRestore();
-    });
-
-    it('should get OTP from header when header name is custom (failed)', async () => {
-      const otpServiceMock = jest
-        .spyOn(OtpService.prototype, 'getTOTP')
-        .mockImplementation();
-
-      const secret = '654321', token = '123456';
-
-      const otp = await setup({
-        secretResolver: () => secret,
-      });
-
-      await request(otp.getHttpServer())
-        .get('/test')
-        .set('X-Quick-Brown-Fox-Jumps-Over-Lazy-Dog', token)
-        .expect(401);
-
-      expect(otpServiceMock).not.toHaveBeenCalled();
-
-      otpServiceMock.mockRestore();
-    });
-
-    it('should get OTP from header when header name is custom (success)', async () => {
-      let otpValidateMock;
-      const otpServiceMock = jest
-          .spyOn(OtpService.prototype, 'getTOTP')
-          .mockImplementation( () => {
-            const totp = new OTPAuth.TOTP({
-              secret: OTPAuth.Secret.fromUTF8('any'),
+            const otp = await setup({
+                secretResolver: () => secret,
             });
-            otpValidateMock = jest.spyOn(totp, 'validate').mockReturnValue(1)
-            return totp;
-          });
 
-      const secret = '654321', token = '123456';
+            await request(otp.getHttpServer())
+                .get('/test')
+                .set('X-Quick-Brown-Fox-Jumps-Over-Lazy-Dog', token)
+                .expect(401);
 
-      const otp = await setup({
-        secretResolver: () => secret,
-        header: 'X-Quick-Brown-Fox-Jumps-Over-Lazy-Dog',
-      });
+            expect(otpServiceMock).not.toHaveBeenCalled();
 
-      await request(otp.getHttpServer())
-        .get('/test')
-        .set('X-Quick-Brown-Fox-Jumps-Over-Lazy-Dog', token)
-        .expect(200);
+            otpServiceMock.mockRestore();
+        });
 
-      expect(otpServiceMock).toHaveBeenNthCalledWith(1, {secret});
-      expect(otpValidateMock).toHaveBeenNthCalledWith(1, {token});
+        it('should get OTP from header when header name is custom (success)', async () => {
+            let otpValidateMock;
+            const otpServiceMock = jest
+                .spyOn(OtpService.prototype, 'getTOTP')
+                .mockImplementation(() => {
+                    const totp = new OTPAuth.TOTP({
+                        secret: OTPAuth.Secret.fromUTF8('any'),
+                    });
+                    otpValidateMock = jest.spyOn(totp, 'validate').mockReturnValue(1)
+                    return totp;
+                });
 
-      otpServiceMock.mockRestore();
-    });
-  });
+            const secret = '654321', token = '123456';
 
-  describe('secret resolver', () => {
-    it('should set up the secret resolver as function', async () => {
-      const secretResolver = jest.fn();
-      secretResolver.mockReturnValue('secret');
-      const requestResolver = jest.fn();
-      const otpResolver = jest.fn();
-      otpResolver.mockReturnValue('123456');
-      const otp = await setup({
-        secretResolver,
-        requestResolver,
-        otpResolver,
-      });
-
-      await request(otp.getHttpServer()).get('/test').expect(401);
-
-      expect(requestResolver).toHaveBeenCalled();
-      expect(otpResolver).toHaveBeenCalled();
-      expect(secretResolver).toHaveBeenCalled();
-    });
-
-    it('should set up the secret resolver as class', async () => {
-      const secretResolver = jest.fn();
-      secretResolver.mockReturnValue('secret');
-      const secretResolverClass = createSecretResolver(secretResolver);
-      const requestResolver = jest.fn();
-      const otpResolver = jest.fn();
-      otpResolver.mockReturnValue('123456');
-      const otp = await setup({
-        secretResolver: secretResolverClass,
-        requestResolver,
-        otpResolver,
-      });
-
-      await request(otp.getHttpServer()).get('/test').expect(401);
-
-      expect(requestResolver).toHaveBeenCalled();
-      expect(otpResolver).toHaveBeenCalled();
-      expect(secretResolver).toHaveBeenCalled();
-    });
-  });
-
-  describe('validation', () => {
-    it('should throw invalid OTP exception (length mismatch)', async () => {
-      const otpServiceMock = jest
-          .spyOn(OtpService.prototype, 'getTOTP')
-          .mockImplementation( () => {
-            const totp = new OTPAuth.TOTP({
-              secret: OTPAuth.Secret.fromUTF8('any'),
+            const otp = await setup({
+                secretResolver: () => secret,
+                header: 'X-Quick-Brown-Fox-Jumps-Over-Lazy-Dog',
             });
-            jest.spyOn(totp, 'validate').mockReturnValue(null)
-            return totp;
-          });
 
-      const secret = '654321', token = '123456';
+            await request(otp.getHttpServer())
+                .get('/test')
+                .set('X-Quick-Brown-Fox-Jumps-Over-Lazy-Dog', token)
+                .expect(200);
 
-      const otp = await setup({
-        secretResolver: () => secret,
-        digits: 8,
-      });
+            expect(otpServiceMock).toHaveBeenNthCalledWith(1, {secret});
+            expect(otpValidateMock).toHaveBeenNthCalledWith(1, {token});
 
-      const response = await request(otp.getHttpServer())
-        .get('/test')
-        .set('X-One-Time-Password', token)
-        .expect(401);
-
-      expect(JSON.parse(response.text)).toMatchObject({
-        message: 'Invalid OTP (length mismatch)',
-      });
-
-      otpServiceMock.mockRestore();
+            otpServiceMock.mockRestore();
+        });
     });
 
-    it('should throw no OTP exception', async () => {
-      const otpServiceMock = jest
-          .spyOn(OtpService.prototype, 'getTOTP')
-          .mockImplementation( () => {
-            const totp = new OTPAuth.TOTP({
-              secret: OTPAuth.Secret.fromUTF8('any'),
+    describe('secret resolver', () => {
+        it('should set up the secret resolver as function', async () => {
+            const secretResolver = jest.fn();
+            secretResolver.mockReturnValue('secret');
+            const requestResolver = jest.fn();
+            const otpResolver = jest.fn();
+            otpResolver.mockReturnValue('123456');
+            const otp = await setup({
+                secretResolver,
+                requestResolver,
+                otpResolver,
             });
-            jest.spyOn(totp, 'validate').mockReturnValue(null)
-            return totp;
-          });
 
-      const secret = '654321'
+            await request(otp.getHttpServer()).get('/test').expect(401);
 
-      const otp = await setup({
-        secretResolver: () => secret
-      });
+            expect(requestResolver).toHaveBeenCalled();
+            expect(otpResolver).toHaveBeenCalled();
+            expect(secretResolver).toHaveBeenCalled();
+        });
 
-      const response = await request(otp.getHttpServer())
-        .get('/test')
-        .expect(401);
-
-      expect(JSON.parse(response.text)).toMatchObject({
-        message: 'No OTP provided',
-      });
-
-      otpServiceMock.mockRestore();
-    });
-
-    it('should throw no secret exception', async () => {
-      const otpServiceMock = jest
-          .spyOn(OtpService.prototype, 'getTOTP')
-          .mockImplementation( () => {
-            const totp = new OTPAuth.TOTP({
-              secret: OTPAuth.Secret.fromUTF8('any'),
+        it('should set up the secret resolver as class', async () => {
+            const secretResolver = jest.fn();
+            secretResolver.mockReturnValue('secret');
+            const secretResolverClass = createSecretResolver(secretResolver);
+            const requestResolver = jest.fn();
+            const otpResolver = jest.fn();
+            otpResolver.mockReturnValue('123456');
+            const otp = await setup({
+                secretResolver: secretResolverClass,
+                requestResolver,
+                otpResolver,
             });
-            jest.spyOn(totp, 'validate').mockReturnValue(null)
-            return totp;
-          });
 
-      const otp = await setup({
-        otpResolver: () => '123456',
-      });
+            await request(otp.getHttpServer()).get('/test').expect(401);
 
-      const response = await request(otp.getHttpServer())
-        .get('/test')
-        .expect(401);
-
-      expect(JSON.parse(response.text)).toMatchObject({
-        message: 'No secret provided',
-      });
-
-      otpServiceMock.mockRestore();
+            expect(requestResolver).toHaveBeenCalled();
+            expect(otpResolver).toHaveBeenCalled();
+            expect(secretResolver).toHaveBeenCalled();
+        });
     });
 
-    it('should set defaults', async () => {
-      const otp = await setup({
-        digits: 1,
-        period: 1,
-      });
+    describe('validation', () => {
+        it('should throw invalid OTP exception (length mismatch)', async () => {
+            const otpServiceMock = jest
+                .spyOn(OtpService.prototype, 'getTOTP')
+                .mockImplementation(() => {
+                    const totp = new OTPAuth.TOTP({
+                        secret: OTPAuth.Secret.fromUTF8('any'),
+                    });
+                    jest.spyOn(totp, 'validate').mockReturnValue(null)
+                    return totp;
+                });
 
-      const otpService = otp.get(OtpService);
+            const secret = '654321', token = '123456';
 
-      expect(otpService.config.digits).toEqual(OTP_MIN_SECURE_DIGITS);
-      expect(otpService.config.period).toEqual(OTP_MIN_SECURE_PERIOD);
-      expect(otpService.config.algorithm).toEqual('SHA1');
-      expect(otpService.config.window).toEqual(1);
-      expect(otpService.config.secretMethod).toEqual('fromUTF8');
-      expect(otpService.config.header).toEqual(OTP_DEFAULT_HEADER);
+            const otp = await setup({
+                secretResolver: () => secret,
+                digits: 8,
+            });
+
+            const response = await request(otp.getHttpServer())
+                .get('/test')
+                .set('X-One-Time-Password', token)
+                .expect(401);
+
+            expect(JSON.parse(response.text)).toMatchObject({
+                message: 'Invalid OTP (length mismatch)',
+            });
+
+            otpServiceMock.mockRestore();
+        });
+
+        it('should throw no OTP exception', async () => {
+            const otpServiceMock = jest
+                .spyOn(OtpService.prototype, 'getTOTP')
+                .mockImplementation(() => {
+                    const totp = new OTPAuth.TOTP({
+                        secret: OTPAuth.Secret.fromUTF8('any'),
+                    });
+                    jest.spyOn(totp, 'validate').mockReturnValue(null)
+                    return totp;
+                });
+
+            const secret = '654321'
+
+            const otp = await setup({
+                secretResolver: () => secret
+            });
+
+            const response = await request(otp.getHttpServer())
+                .get('/test')
+                .expect(401);
+
+            expect(JSON.parse(response.text)).toMatchObject({
+                message: 'No OTP provided',
+            });
+
+            otpServiceMock.mockRestore();
+        });
+
+        it('should throw no secret exception', async () => {
+            const otpServiceMock = jest
+                .spyOn(OtpService.prototype, 'getTOTP')
+                .mockImplementation(() => {
+                    const totp = new OTPAuth.TOTP({
+                        secret: OTPAuth.Secret.fromUTF8('any'),
+                    });
+                    jest.spyOn(totp, 'validate').mockReturnValue(null)
+                    return totp;
+                });
+
+            const otp = await setup({
+                otpResolver: () => '123456',
+            });
+
+            const response = await request(otp.getHttpServer())
+                .get('/test')
+                .expect(401);
+
+            expect(JSON.parse(response.text)).toMatchObject({
+                message: 'No secret provided',
+            });
+
+            otpServiceMock.mockRestore();
+        });
+
+        it('should set defaults', async () => {
+            const otp = await setup({
+                digits: 1,
+                period: 1,
+            });
+
+            const otpService = otp.get(OtpService);
+
+            expect(otpService.config.digits).toEqual(OTP_MIN_SECURE_DIGITS);
+            expect(otpService.config.period).toEqual(OTP_MIN_SECURE_PERIOD);
+            expect(otpService.config.algorithm).toEqual('SHA1');
+            expect(otpService.config.window).toEqual(1);
+            expect(otpService.config.secretMethod).toEqual('fromUTF8');
+            expect(otpService.config.header).toEqual(OTP_DEFAULT_HEADER);
+        });
+
+        it('should warn on init', async () => {
+            const loggerMock = jest.spyOn(Logger.prototype, 'warn');
+
+            const otp = await setup({
+                digits: 4,
+                period: 15,
+            });
+
+            expect(loggerMock).toHaveBeenCalledWith(
+                `Insecure number of digits provided for OTP (4)`,
+            );
+            expect(loggerMock).toHaveBeenCalledWith(
+                `Consider using a different period for OTP instead of 15`,
+            );
+            expect(loggerMock).toHaveBeenCalledWith(
+                `No secret resolver provided. Module might not work properly!`,
+            );
+        });
     });
-
-    it('should warn on init', async () => {
-      const loggerMock = jest.spyOn(Logger.prototype, 'warn');
-
-      const otp = await setup({
-        digits: 4,
-        period: 15,
-      });
-
-      expect(loggerMock).toHaveBeenCalledWith(
-        `Insecure number of digits provided for OTP (4)`,
-      );
-      expect(loggerMock).toHaveBeenCalledWith(
-        `Consider using a different period for OTP instead of 15`,
-      );
-      expect(loggerMock).toHaveBeenCalledWith(
-        `No secret resolver provided. Module might not work properly!`,
-      );
-    });
-  });
 });

--- a/lib/__tests__/otp.guard.spec.ts
+++ b/lib/__tests__/otp.guard.spec.ts
@@ -303,6 +303,27 @@ describe('OtpModule', () => {
       expect(config.header).toEqual(OTP_DEFAULT_HEADER);
     });
 
+    it('should NOT set defaults on register async when skipValidation is truthy', async () => {
+      const otp = await setup(
+        {
+          digits: 1,
+          period: 1,
+          skipValidation: true,
+        },
+        undefined,
+        true,
+      );
+
+      const config = otp.get<IOtpModuleOptions>(OTP_CONFIG_TOKEN);
+
+      expect(config.digits).not.toEqual(OTP_MIN_SECURE_DIGITS);
+      expect(config.period).not.toEqual(OTP_MIN_SECURE_PERIOD);
+      expect(config.algorithm).not.toBeDefined();
+      expect(config.window).not.toBeDefined();
+      expect(config.secretMethod).not.toBeDefined();
+      expect(config.header).not.toBeDefined();
+    });
+
     it('should warn on init', async () => {
       const loggerMock = jest.spyOn(Logger.prototype, 'warn');
 
@@ -318,6 +339,26 @@ describe('OtpModule', () => {
         `Consider using a different period for OTP instead of 15`,
       );
       expect(loggerMock).toHaveBeenCalledWith(
+        `No secret resolver provided. Module might not work properly!`,
+      );
+    });
+
+    it('should not warn on init when in silent mode', async () => {
+      const loggerMock = jest.spyOn(Logger.prototype, 'warn');
+
+      await setup({
+        digits: 4,
+        period: 15,
+        silent: true,
+      });
+
+      expect(loggerMock).not.toHaveBeenCalledWith(
+        `Insecure number of digits provided for OTP (4)`,
+      );
+      expect(loggerMock).not.toHaveBeenCalledWith(
+        `Consider using a different period for OTP instead of 15`,
+      );
+      expect(loggerMock).not.toHaveBeenCalledWith(
         `No secret resolver provided. Module might not work properly!`,
       );
     });

--- a/lib/__tests__/otp.guard.spec.ts
+++ b/lib/__tests__/otp.guard.spec.ts
@@ -288,6 +288,9 @@ describe('OtpModule', () => {
       expect(loggerMock).toHaveBeenCalledWith(
         `Consider using a different period for OTP instead of 15`,
       );
+      expect(loggerMock).toHaveBeenCalledWith(
+        `No secret resolver provided. Module might not work properly!`,
+      );
     });
   });
 });

--- a/lib/__tests__/otp.guard.spec.ts
+++ b/lib/__tests__/otp.guard.spec.ts
@@ -1,292 +1,325 @@
-import {IOtpModuleOptions, IOtpSecretResolver} from '../interfaces';
-import {Test} from '@nestjs/testing';
-import {OtpModule} from '../otp.module';
-import {TestController} from './test-utils/test.controller';
+import { IOtpModuleOptions, IOtpSecretResolver } from '../interfaces';
+import { Test } from '@nestjs/testing';
+import { OtpModule } from '../otp.module';
+import { TestController } from './test-utils/test.controller';
 import request from 'supertest';
-import {Request} from 'express';
-import {OtpService} from '../services';
-import {OTP_DEFAULT_HEADER, OTP_MIN_SECURE_DIGITS, OTP_MIN_SECURE_PERIOD,} from '../otp.constants';
-import {Logger} from '@nestjs/common';
-import * as OTPAuth from "otpauth";
+import { Request } from 'express';
+import { OtpService } from '../services';
+import {
+  OTP_CONFIG_TOKEN,
+  OTP_DEFAULT_HEADER,
+  OTP_MIN_SECURE_DIGITS,
+  OTP_MIN_SECURE_PERIOD,
+} from '../otp.constants';
+import { Logger } from '@nestjs/common';
+import * as OTPAuth from 'otpauth';
 
 const setup = async (
-    config: Partial<IOtpModuleOptions>,
-    otpServiceMock?: any,
+  config: Partial<IOtpModuleOptions>,
+  otpServiceMock?: any,
+  useAsyncRegister?: boolean,
 ) => {
-    const module = await Test.createTestingModule({
-        imports: [
-            OtpModule.register({label: 'Label', issuer: 'Issuer', ...config}),
-        ],
-        providers: otpServiceMock
-            ? [
-                {
-                    provide: OtpService,
-                    useExisting: otpServiceMock,
-                },
-            ]
-            : [],
-        controllers: [TestController],
-    }).compile();
+  const module = await Test.createTestingModule({
+    imports: [
+      !useAsyncRegister
+        ? OtpModule.register({ label: 'Label', issuer: 'Issuer', ...config })
+        : OtpModule.registerAsync({
+            useFactory: () => ({ label: 'Label', issuer: 'Issuer', ...config }),
+          }),
+    ],
+    providers: otpServiceMock
+      ? [
+          {
+            provide: OtpService,
+            useExisting: otpServiceMock,
+          },
+        ]
+      : [],
+    controllers: [TestController],
+  }).compile();
 
-    const app = module.createNestApplication();
-    return app.init();
+  const app = module.createNestApplication();
+  return app.init();
 };
 
 const createSecretResolver = (mock: Function) => {
-    return new (class implements IOtpSecretResolver {
-        resolve(request: Request) {
-            return mock(request);
-        }
-    })();
+  return new (class implements IOtpSecretResolver {
+    resolve(request: Request) {
+      return mock(request);
+    }
+  })();
 };
 
 describe('OtpModule', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
-    afterEach(() => {
-        jest.clearAllMocks();
-    })
-
-    describe('otp resolver', () => {
-        it('should get OTP from header', async () => {
-            let otpValidateMock;
-            const otpServiceMock = jest
-                .spyOn(OtpService.prototype, 'getTOTP')
-                .mockImplementation(() => {
-                    const totp = new OTPAuth.TOTP({
-                        secret: OTPAuth.Secret.fromUTF8('any'),
-                    });
-                    otpValidateMock = jest.spyOn(totp, 'validate').mockReturnValue(1)
-                    return totp;
-                });
-
-            const secret = '654321', token = '123456';
-
-            const otp = await setup({
-                secretResolver: () => secret,
-            });
-
-            await request(otp.getHttpServer())
-                .get('/test')
-                .set('X-One-Time-Password', token)
-                .expect(200);
-
-            expect(otpValidateMock).toHaveBeenNthCalledWith(1, {token});
-            expect(otpServiceMock).toHaveBeenNthCalledWith(1, {secret});
-
-            otpServiceMock.mockRestore();
+  describe('otp resolver', () => {
+    it('should get OTP from header', async () => {
+      let otpValidateMock;
+      const otpServiceMock = jest
+        .spyOn(OtpService.prototype, 'getTOTP')
+        .mockImplementation(() => {
+          const totp = new OTPAuth.TOTP({
+            secret: OTPAuth.Secret.fromUTF8('any'),
+          });
+          otpValidateMock = jest.spyOn(totp, 'validate').mockReturnValue(1);
+          return totp;
         });
 
-        it('should get OTP from header when header name is custom (failed)', async () => {
-            const otpServiceMock = jest
-                .spyOn(OtpService.prototype, 'getTOTP')
-                .mockImplementation();
+      const secret = '654321',
+        token = '123456';
 
-            const secret = '654321', token = '123456';
+      const otp = await setup({
+        secretResolver: () => secret,
+      });
 
-            const otp = await setup({
-                secretResolver: () => secret,
-            });
+      await request(otp.getHttpServer())
+        .get('/test')
+        .set('X-One-Time-Password', token)
+        .expect(200);
 
-            await request(otp.getHttpServer())
-                .get('/test')
-                .set('X-Quick-Brown-Fox-Jumps-Over-Lazy-Dog', token)
-                .expect(401);
+      expect(otpValidateMock).toHaveBeenNthCalledWith(1, { token });
+      expect(otpServiceMock).toHaveBeenNthCalledWith(1, { secret });
 
-            expect(otpServiceMock).not.toHaveBeenCalled();
-
-            otpServiceMock.mockRestore();
-        });
-
-        it('should get OTP from header when header name is custom (success)', async () => {
-            let otpValidateMock;
-            const otpServiceMock = jest
-                .spyOn(OtpService.prototype, 'getTOTP')
-                .mockImplementation(() => {
-                    const totp = new OTPAuth.TOTP({
-                        secret: OTPAuth.Secret.fromUTF8('any'),
-                    });
-                    otpValidateMock = jest.spyOn(totp, 'validate').mockReturnValue(1)
-                    return totp;
-                });
-
-            const secret = '654321', token = '123456';
-
-            const otp = await setup({
-                secretResolver: () => secret,
-                header: 'X-Quick-Brown-Fox-Jumps-Over-Lazy-Dog',
-            });
-
-            await request(otp.getHttpServer())
-                .get('/test')
-                .set('X-Quick-Brown-Fox-Jumps-Over-Lazy-Dog', token)
-                .expect(200);
-
-            expect(otpServiceMock).toHaveBeenNthCalledWith(1, {secret});
-            expect(otpValidateMock).toHaveBeenNthCalledWith(1, {token});
-
-            otpServiceMock.mockRestore();
-        });
+      otpServiceMock.mockRestore();
     });
 
-    describe('secret resolver', () => {
-        it('should set up the secret resolver as function', async () => {
-            const secretResolver = jest.fn();
-            secretResolver.mockReturnValue('secret');
-            const requestResolver = jest.fn();
-            const otpResolver = jest.fn();
-            otpResolver.mockReturnValue('123456');
-            const otp = await setup({
-                secretResolver,
-                requestResolver,
-                otpResolver,
-            });
+    it('should get OTP from header when header name is custom (failed)', async () => {
+      const otpServiceMock = jest
+        .spyOn(OtpService.prototype, 'getTOTP')
+        .mockImplementation();
 
-            await request(otp.getHttpServer()).get('/test').expect(401);
+      const secret = '654321',
+        token = '123456';
 
-            expect(requestResolver).toHaveBeenCalled();
-            expect(otpResolver).toHaveBeenCalled();
-            expect(secretResolver).toHaveBeenCalled();
-        });
+      const otp = await setup({
+        secretResolver: () => secret,
+      });
 
-        it('should set up the secret resolver as class', async () => {
-            const secretResolver = jest.fn();
-            secretResolver.mockReturnValue('secret');
-            const secretResolverClass = createSecretResolver(secretResolver);
-            const requestResolver = jest.fn();
-            const otpResolver = jest.fn();
-            otpResolver.mockReturnValue('123456');
-            const otp = await setup({
-                secretResolver: secretResolverClass,
-                requestResolver,
-                otpResolver,
-            });
+      await request(otp.getHttpServer())
+        .get('/test')
+        .set('X-Quick-Brown-Fox-Jumps-Over-Lazy-Dog', token)
+        .expect(401);
 
-            await request(otp.getHttpServer()).get('/test').expect(401);
+      expect(otpServiceMock).not.toHaveBeenCalled();
 
-            expect(requestResolver).toHaveBeenCalled();
-            expect(otpResolver).toHaveBeenCalled();
-            expect(secretResolver).toHaveBeenCalled();
-        });
+      otpServiceMock.mockRestore();
     });
 
-    describe('validation', () => {
-        it('should throw invalid OTP exception (length mismatch)', async () => {
-            const otpServiceMock = jest
-                .spyOn(OtpService.prototype, 'getTOTP')
-                .mockImplementation(() => {
-                    const totp = new OTPAuth.TOTP({
-                        secret: OTPAuth.Secret.fromUTF8('any'),
-                    });
-                    jest.spyOn(totp, 'validate').mockReturnValue(null)
-                    return totp;
-                });
-
-            const secret = '654321', token = '123456';
-
-            const otp = await setup({
-                secretResolver: () => secret,
-                digits: 8,
-            });
-
-            const response = await request(otp.getHttpServer())
-                .get('/test')
-                .set('X-One-Time-Password', token)
-                .expect(401);
-
-            expect(JSON.parse(response.text)).toMatchObject({
-                message: 'Invalid OTP (length mismatch)',
-            });
-
-            otpServiceMock.mockRestore();
+    it('should get OTP from header when header name is custom (success)', async () => {
+      let otpValidateMock;
+      const otpServiceMock = jest
+        .spyOn(OtpService.prototype, 'getTOTP')
+        .mockImplementation(() => {
+          const totp = new OTPAuth.TOTP({
+            secret: OTPAuth.Secret.fromUTF8('any'),
+          });
+          otpValidateMock = jest.spyOn(totp, 'validate').mockReturnValue(1);
+          return totp;
         });
 
-        it('should throw no OTP exception', async () => {
-            const otpServiceMock = jest
-                .spyOn(OtpService.prototype, 'getTOTP')
-                .mockImplementation(() => {
-                    const totp = new OTPAuth.TOTP({
-                        secret: OTPAuth.Secret.fromUTF8('any'),
-                    });
-                    jest.spyOn(totp, 'validate').mockReturnValue(null)
-                    return totp;
-                });
+      const secret = '654321',
+        token = '123456';
 
-            const secret = '654321'
+      const otp = await setup({
+        secretResolver: () => secret,
+        header: 'X-Quick-Brown-Fox-Jumps-Over-Lazy-Dog',
+      });
 
-            const otp = await setup({
-                secretResolver: () => secret
-            });
+      await request(otp.getHttpServer())
+        .get('/test')
+        .set('X-Quick-Brown-Fox-Jumps-Over-Lazy-Dog', token)
+        .expect(200);
 
-            const response = await request(otp.getHttpServer())
-                .get('/test')
-                .expect(401);
+      expect(otpServiceMock).toHaveBeenNthCalledWith(1, { secret });
+      expect(otpValidateMock).toHaveBeenNthCalledWith(1, { token });
 
-            expect(JSON.parse(response.text)).toMatchObject({
-                message: 'No OTP provided',
-            });
-
-            otpServiceMock.mockRestore();
-        });
-
-        it('should throw no secret exception', async () => {
-            const otpServiceMock = jest
-                .spyOn(OtpService.prototype, 'getTOTP')
-                .mockImplementation(() => {
-                    const totp = new OTPAuth.TOTP({
-                        secret: OTPAuth.Secret.fromUTF8('any'),
-                    });
-                    jest.spyOn(totp, 'validate').mockReturnValue(null)
-                    return totp;
-                });
-
-            const otp = await setup({
-                otpResolver: () => '123456',
-            });
-
-            const response = await request(otp.getHttpServer())
-                .get('/test')
-                .expect(401);
-
-            expect(JSON.parse(response.text)).toMatchObject({
-                message: 'No secret provided',
-            });
-
-            otpServiceMock.mockRestore();
-        });
-
-        it('should set defaults', async () => {
-            const otp = await setup({
-                digits: 1,
-                period: 1,
-            });
-
-            const otpService = otp.get(OtpService);
-
-            expect(otpService.config.digits).toEqual(OTP_MIN_SECURE_DIGITS);
-            expect(otpService.config.period).toEqual(OTP_MIN_SECURE_PERIOD);
-            expect(otpService.config.algorithm).toEqual('SHA1');
-            expect(otpService.config.window).toEqual(1);
-            expect(otpService.config.secretMethod).toEqual('fromUTF8');
-            expect(otpService.config.header).toEqual(OTP_DEFAULT_HEADER);
-        });
-
-        it('should warn on init', async () => {
-            const loggerMock = jest.spyOn(Logger.prototype, 'warn');
-
-            const otp = await setup({
-                digits: 4,
-                period: 15,
-            });
-
-            expect(loggerMock).toHaveBeenCalledWith(
-                `Insecure number of digits provided for OTP (4)`,
-            );
-            expect(loggerMock).toHaveBeenCalledWith(
-                `Consider using a different period for OTP instead of 15`,
-            );
-            expect(loggerMock).toHaveBeenCalledWith(
-                `No secret resolver provided. Module might not work properly!`,
-            );
-        });
+      otpServiceMock.mockRestore();
     });
+  });
+
+  describe('secret resolver', () => {
+    it('should set up the secret resolver as function', async () => {
+      const secretResolver = jest.fn();
+      secretResolver.mockReturnValue('secret');
+      const requestResolver = jest.fn();
+      const otpResolver = jest.fn();
+      otpResolver.mockReturnValue('123456');
+      const otp = await setup({
+        secretResolver,
+        requestResolver,
+        otpResolver,
+      });
+
+      await request(otp.getHttpServer()).get('/test').expect(401);
+
+      expect(requestResolver).toHaveBeenCalled();
+      expect(otpResolver).toHaveBeenCalled();
+      expect(secretResolver).toHaveBeenCalled();
+    });
+
+    it('should set up the secret resolver as class', async () => {
+      const secretResolver = jest.fn();
+      secretResolver.mockReturnValue('secret');
+      const secretResolverClass = createSecretResolver(secretResolver);
+      const requestResolver = jest.fn();
+      const otpResolver = jest.fn();
+      otpResolver.mockReturnValue('123456');
+      const otp = await setup({
+        secretResolver: secretResolverClass,
+        requestResolver,
+        otpResolver,
+      });
+
+      await request(otp.getHttpServer()).get('/test').expect(401);
+
+      expect(requestResolver).toHaveBeenCalled();
+      expect(otpResolver).toHaveBeenCalled();
+      expect(secretResolver).toHaveBeenCalled();
+    });
+  });
+
+  describe('validation', () => {
+    it('should throw invalid OTP exception (length mismatch)', async () => {
+      const otpServiceMock = jest
+        .spyOn(OtpService.prototype, 'getTOTP')
+        .mockImplementation(() => {
+          const totp = new OTPAuth.TOTP({
+            secret: OTPAuth.Secret.fromUTF8('any'),
+          });
+          jest.spyOn(totp, 'validate').mockReturnValue(null);
+          return totp;
+        });
+
+      const secret = '654321',
+        token = '123456';
+
+      const otp = await setup({
+        secretResolver: () => secret,
+        digits: 8,
+      });
+
+      const response = await request(otp.getHttpServer())
+        .get('/test')
+        .set('X-One-Time-Password', token)
+        .expect(401);
+
+      expect(JSON.parse(response.text)).toMatchObject({
+        message: 'Invalid OTP (length mismatch)',
+      });
+
+      otpServiceMock.mockRestore();
+    });
+
+    it('should throw no OTP exception', async () => {
+      const otpServiceMock = jest
+        .spyOn(OtpService.prototype, 'getTOTP')
+        .mockImplementation(() => {
+          const totp = new OTPAuth.TOTP({
+            secret: OTPAuth.Secret.fromUTF8('any'),
+          });
+          jest.spyOn(totp, 'validate').mockReturnValue(null);
+          return totp;
+        });
+
+      const secret = '654321';
+
+      const otp = await setup({
+        secretResolver: () => secret,
+      });
+
+      const response = await request(otp.getHttpServer())
+        .get('/test')
+        .expect(401);
+
+      expect(JSON.parse(response.text)).toMatchObject({
+        message: 'No OTP provided',
+      });
+
+      otpServiceMock.mockRestore();
+    });
+
+    it('should throw no secret exception', async () => {
+      const otpServiceMock = jest
+        .spyOn(OtpService.prototype, 'getTOTP')
+        .mockImplementation(() => {
+          const totp = new OTPAuth.TOTP({
+            secret: OTPAuth.Secret.fromUTF8('any'),
+          });
+          jest.spyOn(totp, 'validate').mockReturnValue(null);
+          return totp;
+        });
+
+      const otp = await setup({
+        otpResolver: () => '123456',
+      });
+
+      const response = await request(otp.getHttpServer())
+        .get('/test')
+        .expect(401);
+
+      expect(JSON.parse(response.text)).toMatchObject({
+        message: 'No secret provided',
+      });
+
+      otpServiceMock.mockRestore();
+    });
+
+    it('should set defaults', async () => {
+      const otp = await setup({
+        digits: 1,
+        period: 1,
+      });
+
+      const config = otp.get<IOtpModuleOptions>(OTP_CONFIG_TOKEN);
+
+      expect(config.digits).toEqual(OTP_MIN_SECURE_DIGITS);
+      expect(config.period).toEqual(OTP_MIN_SECURE_PERIOD);
+      expect(config.algorithm).toEqual('SHA1');
+      expect(config.window).toEqual(1);
+      expect(config.secretMethod).toEqual('fromUTF8');
+      expect(config.header).toEqual(OTP_DEFAULT_HEADER);
+    });
+
+    it('should set defaults on register async', async () => {
+      const otp = await setup(
+        {
+          digits: 1,
+          period: 1,
+        },
+        undefined,
+        true,
+      );
+
+      const config = otp.get<IOtpModuleOptions>(OTP_CONFIG_TOKEN);
+
+      expect(config.digits).toEqual(OTP_MIN_SECURE_DIGITS);
+      expect(config.period).toEqual(OTP_MIN_SECURE_PERIOD);
+      expect(config.algorithm).toEqual('SHA1');
+      expect(config.window).toEqual(1);
+      expect(config.secretMethod).toEqual('fromUTF8');
+      expect(config.header).toEqual(OTP_DEFAULT_HEADER);
+    });
+
+    it('should warn on init', async () => {
+      const loggerMock = jest.spyOn(Logger.prototype, 'warn');
+
+      await setup({
+        digits: 4,
+        period: 15,
+      });
+
+      expect(loggerMock).toHaveBeenCalledWith(
+        `Insecure number of digits provided for OTP (4)`,
+      );
+      expect(loggerMock).toHaveBeenCalledWith(
+        `Consider using a different period for OTP instead of 15`,
+      );
+      expect(loggerMock).toHaveBeenCalledWith(
+        `No secret resolver provided. Module might not work properly!`,
+      );
+    });
+  });
 });

--- a/lib/__tests__/test-utils/test.controller.ts
+++ b/lib/__tests__/test-utils/test.controller.ts
@@ -1,11 +1,11 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
-import { OtpGuard } from '../../guards';
+import {Controller, Get, UseGuards} from '@nestjs/common';
+import {OtpGuard} from '../../guards';
 
 @Controller('test')
 export class TestController {
-  @UseGuards(OtpGuard)
-  @Get('/')
-  test(): string {
-    return 'test';
-  }
+    @UseGuards(OtpGuard)
+    @Get('/')
+    test(): string {
+        return 'test';
+    }
 }

--- a/lib/__tests__/test-utils/test.controller.ts
+++ b/lib/__tests__/test-utils/test.controller.ts
@@ -1,11 +1,11 @@
-import {Controller, Get, UseGuards} from '@nestjs/common';
-import {OtpGuard} from '../../guards';
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { OtpGuard } from '../../guards';
 
 @Controller('test')
 export class TestController {
-    @UseGuards(OtpGuard)
-    @Get('/')
-    test(): string {
-        return 'test';
-    }
+  @UseGuards(OtpGuard)
+  @Get('/')
+  test(): string {
+    return 'test';
+  }
 }

--- a/lib/guards/otp.guard.ts
+++ b/lib/guards/otp.guard.ts
@@ -18,11 +18,10 @@ import { OTP_CONFIG_TOKEN } from '../otp.constants';
  */
 @Injectable()
 export class OtpGuard implements CanActivate {
-  @Inject(OtpService)
-  private readonly otpService: OtpService;
-
   @Inject(OTP_CONFIG_TOKEN)
   protected readonly config: Required<IOtpModuleOptions>;
+  @Inject(OtpService)
+  private readonly otpService: OtpService;
 
   private static resolveSecretResolver(
     options: Pick<IOtpModuleOptions, 'secretResolver'>,
@@ -62,8 +61,9 @@ export class OtpGuard implements CanActivate {
   /**
    * Gets the secret used for OTP verification.
    * @returns The secret.
+   * @protected
    */
-  async getSecret(request: Request): Promise<string | undefined> {
+  protected async getSecret(request: Request): Promise<string | undefined> {
     return OtpGuard.resolveSecretResolver(this.config)(request);
   }
 
@@ -71,8 +71,9 @@ export class OtpGuard implements CanActivate {
    * Gets the request from the execution context or request resolver if configured.
    * @param context The execution context.
    * @returns The request.
+   * @protected
    */
-  getRequest(context: ExecutionContext) {
+  protected getRequest(context: ExecutionContext) {
     if (this.config.requestResolver) {
       return this.config.requestResolver(context);
     }
@@ -83,8 +84,9 @@ export class OtpGuard implements CanActivate {
    * Gets the OTP from the request or OTP token resolver if configured.
    * @param request The request.
    * @returns The OTP.
+   * @protected
    */
-  async extractOtpToken(request: Request): Promise<string> {
+  protected async extractOtpToken(request: Request): Promise<string> {
     if (this.config.otpResolver) {
       return this.config.otpResolver(request);
     }

--- a/lib/guards/otp.guard.ts
+++ b/lib/guards/otp.guard.ts
@@ -18,11 +18,11 @@ import { OTP_CONFIG_TOKEN } from '../otp.constants';
  */
 @Injectable()
 export class OtpGuard implements CanActivate {
-  constructor(
-    private readonly otpService: OtpService,
-    @Inject(OTP_CONFIG_TOKEN)
-    private readonly config: Required<IOtpModuleOptions>,
-  ) {}
+  @Inject(OtpService)
+  private readonly otpService: OtpService;
+
+  @Inject(OTP_CONFIG_TOKEN)
+  protected readonly config: Required<IOtpModuleOptions>;
 
   private static resolveSecretResolver(
     options: Pick<IOtpModuleOptions, 'secretResolver'>,

--- a/lib/guards/otp.guard.ts
+++ b/lib/guards/otp.guard.ts
@@ -54,31 +54,6 @@ export class OtpGuard implements CanActivate {
   }
 
   /**
-   * Verify an OTP token against a secret.
-   * @param token - The OTP token to verify.
-   * @param secret - The secret used to verify the token.
-   * @param shouldThrow - Whether to throw an exception if the token is invalid.
-   * @returns Whether the token is valid.
-   * @throws {UnauthorizedException} If the token is invalid and `shouldThrow` is true.
-   */
-  private async verify(
-    token: string,
-    secret: string,
-    shouldThrow = true,
-  ): Promise<boolean> {
-    const otp = this.otpService.getTOTP({
-      secret,
-    });
-    const res = otp.validate({
-      token,
-    });
-    if (res === null && shouldThrow) {
-      throw new UnauthorizedException();
-    }
-    return res !== null;
-  }
-
-  /**
    * Gets the secret used for OTP verification.
    * @returns The secret.
    */
@@ -117,6 +92,31 @@ export class OtpGuard implements CanActivate {
     }
 
     return Promise.resolve(Array.isArray(otp) ? otp[0] : otp);
+  }
+
+  /**
+   * Verify an OTP token against a secret.
+   * @param token - The OTP token to verify.
+   * @param secret - The secret used to verify the token.
+   * @param shouldThrow - Whether to throw an exception if the token is invalid.
+   * @returns Whether the token is valid.
+   * @throws {UnauthorizedException} If the token is invalid and `shouldThrow` is true.
+   */
+  private async verify(
+    token: string,
+    secret: string,
+    shouldThrow = true,
+  ): Promise<boolean> {
+    const otp = this.otpService.getTOTP({
+      secret,
+    });
+    const res = otp.validate({
+      token,
+    });
+    if (res === null && shouldThrow) {
+      throw new UnauthorizedException();
+    }
+    return res !== null;
   }
 
   private validateSecret(secret?: string): void {

--- a/lib/guards/otp.guard.ts
+++ b/lib/guards/otp.guard.ts
@@ -107,8 +107,9 @@ export class OtpGuard implements CanActivate {
    * @param shouldThrow - Whether to throw an exception if the token is invalid.
    * @returns Whether the token is valid.
    * @throws {UnauthorizedException} If the token is invalid and `shouldThrow` is true.
+   * @protected
    */
-  private async verify(
+  protected async verify(
     token: string,
     secret: string,
     shouldThrow = true,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
 export * from './interfaces';
 export * from './otp.module';
-export * from './otp.service';
+export * from './services';
 export * from './guards';

--- a/lib/interfaces/otp.interface.ts
+++ b/lib/interfaces/otp.interface.ts
@@ -21,6 +21,16 @@ export type TOtpSecretResolver =
  */
 export interface IOtpModuleOptions {
   /**
+   * Flag to disable validation of module config options.
+   */
+  skipValidation?: boolean;
+
+  /**
+   * Flag to disable logger warnings on module config resolution.
+   */
+  silent?: boolean;
+
+  /**
    * The issuer of the OTP.
    */
   issuer: string;

--- a/lib/otp.config-resolver.ts
+++ b/lib/otp.config-resolver.ts
@@ -1,0 +1,108 @@
+import { IOtpModuleOptions } from './interfaces';
+import { Logger } from '@nestjs/common';
+import {
+  OTP_DEFAULT_HEADER,
+  OTP_MAX_SECURE_PERIOD,
+  OTP_MIN_DIGITS,
+  OTP_MIN_PERIOD,
+  OTP_MIN_SECURE_DIGITS,
+  OTP_MIN_SECURE_PERIOD,
+} from './otp.constants';
+
+class OtpLogger extends Logger {
+  constructor(private readonly silent: boolean) {
+    super(OtpConfigResolver.name);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  warn(message: any, _context?: string) {
+    if (!this.silent) {
+      super.warn(message);
+    }
+  }
+}
+
+export class OtpConfigResolver {
+  public static resolveConfig(
+    config: IOtpModuleOptions,
+  ): Required<IOtpModuleOptions> {
+    return OtpConfigResolver.setDefaultOpts(
+      OtpConfigResolver.validateOpts(config),
+    );
+  }
+
+  private static validateOpts(config: IOtpModuleOptions) {
+    const logger = new OtpLogger(!!config.silent);
+
+    if (!config.secretResolver) {
+      logger.warn(
+        'No secret resolver provided. Module might not work properly!',
+      );
+    }
+
+    if (!config.label) {
+      logger.warn('No label provided for OTP, defaulting to "OTP"');
+      if (!config.skipValidation) {
+        config.label = 'OTP';
+      }
+    }
+
+    if (!config.issuer) {
+      logger.warn('No issuer provided for OTP, defaulting to "OTP"');
+
+      if (!config.skipValidation) {
+        config.issuer = 'OTP';
+      }
+    }
+
+    if (
+      !config.skipValidation &&
+      config.digits !== undefined &&
+      config.digits <= OTP_MIN_DIGITS
+    ) {
+      logger.warn(
+        `Invalid digits provided for OTP ${config.digits}, defaulting to ${OTP_MIN_SECURE_DIGITS}`,
+      );
+      config.digits = OTP_MIN_SECURE_DIGITS;
+    } else if (config.digits < OTP_MIN_SECURE_DIGITS) {
+      logger.warn(
+        `Insecure number of digits provided for OTP (${config.digits})`,
+      );
+    }
+
+    if (
+      !config.skipValidation &&
+      config.period !== undefined &&
+      config.period <= OTP_MIN_PERIOD
+    ) {
+      logger.warn(
+        `Invalid period provided for OTP ${config.period}, defaulting to ${OTP_MIN_SECURE_PERIOD}`,
+      );
+      config.period = OTP_MIN_SECURE_PERIOD;
+    } else if (
+      config.period < OTP_MIN_SECURE_PERIOD ||
+      config.period > OTP_MAX_SECURE_PERIOD
+    ) {
+      logger.warn(
+        `Consider using a different period for OTP instead of ${config.period}`,
+      );
+    }
+
+    return config;
+  }
+
+  private static setDefaultOpts(
+    config: IOtpModuleOptions,
+  ): Required<IOtpModuleOptions> {
+    const defaults: Omit<IOtpModuleOptions, 'label' | 'issuer'> = {
+      issuerInLabel: config.skipValidation ? config.issuerInLabel : false,
+      algorithm: config.skipValidation ? config.algorithm : 'SHA1',
+      digits: config.skipValidation ? config.digits : OTP_MIN_SECURE_DIGITS,
+      period: config.skipValidation ? config.period : OTP_MIN_SECURE_PERIOD,
+      header: config.skipValidation ? config.header : OTP_DEFAULT_HEADER,
+      window: config.skipValidation ? config.window : 1,
+      secretMethod: config.skipValidation ? config.secretMethod : 'fromUTF8',
+    };
+    return { ...defaults, ...config } as Required<IOtpModuleOptions>;
+  }
+}

--- a/lib/otp.module.ts
+++ b/lib/otp.module.ts
@@ -1,5 +1,5 @@
 import { DynamicModule, Module } from '@nestjs/common';
-import { OtpService } from './otp.service';
+import { OtpService } from './services/otp.service';
 import { IOtpModuleAsyncOptions, IOtpModuleOptions } from './interfaces';
 import { OTP_CONFIG_TOKEN } from './otp.constants';
 

--- a/lib/otp.module.ts
+++ b/lib/otp.module.ts
@@ -1,15 +1,8 @@
-import { DynamicModule, Logger, Module } from '@nestjs/common';
+import { DynamicModule, Module } from '@nestjs/common';
 import { OtpService } from './services';
 import { IOtpModuleAsyncOptions, IOtpModuleOptions } from './interfaces';
-import {
-  OTP_CONFIG_TOKEN,
-  OTP_DEFAULT_HEADER,
-  OTP_MAX_SECURE_PERIOD,
-  OTP_MIN_DIGITS,
-  OTP_MIN_PERIOD,
-  OTP_MIN_SECURE_DIGITS,
-  OTP_MIN_SECURE_PERIOD,
-} from './otp.constants';
+import { OTP_CONFIG_TOKEN } from './otp.constants';
+import { OtpConfigResolver } from './otp.config-resolver';
 
 @Module({})
 export class OtpModule {
@@ -23,7 +16,7 @@ export class OtpModule {
       providers: [
         {
           provide: OTP_CONFIG_TOKEN,
-          useValue: OtpModule.resolveConfig(opts),
+          useValue: OtpConfigResolver.resolveConfig(opts),
         },
         OtpService,
       ],
@@ -48,80 +41,12 @@ export class OtpModule {
         {
           provide: OTP_CONFIG_TOKEN,
           useFactory: (configTemp: IOtpModuleOptions) =>
-            OtpModule.resolveConfig(configTemp),
+            OtpConfigResolver.resolveConfig(configTemp),
           inject: [`${OTP_CONFIG_TOKEN}_TEMP`],
         },
         OtpService,
       ],
       exports: [OTP_CONFIG_TOKEN, OtpService],
     };
-  }
-
-  private static resolveConfig(
-    config: IOtpModuleOptions,
-  ): Required<IOtpModuleOptions> {
-    return OtpModule.setDefaultOpts(OtpModule.validateOpts(config));
-  }
-
-  private static validateOpts(config: IOtpModuleOptions) {
-    const logger = new Logger(OtpModule.name);
-
-    if (!config.secretResolver) {
-      logger.warn(
-        'No secret resolver provided. Module might not work properly!',
-      );
-    }
-
-    if (!config.label) {
-      logger.warn('No label provided for OTP, defaulting to "OTP"');
-      config.label = 'OTP';
-    }
-
-    if (!config.issuer) {
-      logger.warn('No issuer provided for OTP, defaulting to "OTP"');
-      config.issuer = 'OTP';
-    }
-
-    if (config.digits !== undefined && config.digits <= OTP_MIN_DIGITS) {
-      logger.warn(
-        `Invalid digits provided for OTP ${config.digits}, defaulting to ${OTP_MIN_SECURE_DIGITS}`,
-      );
-      config.digits = OTP_MIN_SECURE_DIGITS;
-    } else if (config.digits < OTP_MIN_SECURE_DIGITS) {
-      logger.warn(
-        `Insecure number of digits provided for OTP (${config.digits})`,
-      );
-    }
-
-    if (config.period !== undefined && config.period <= OTP_MIN_PERIOD) {
-      logger.warn(
-        `Invalid period provided for OTP ${config.period}, defaulting to ${OTP_MIN_SECURE_PERIOD}`,
-      );
-      config.period = OTP_MIN_SECURE_PERIOD;
-    } else if (
-      config.period < OTP_MIN_SECURE_PERIOD ||
-      config.period > OTP_MAX_SECURE_PERIOD
-    ) {
-      logger.warn(
-        `Consider using a different period for OTP instead of ${config.period}`,
-      );
-    }
-
-    return config;
-  }
-
-  private static setDefaultOpts(
-    config: IOtpModuleOptions,
-  ): Required<IOtpModuleOptions> {
-    const defaults: Omit<IOtpModuleOptions, 'label' | 'issuer'> = {
-      issuerInLabel: false,
-      algorithm: 'SHA1',
-      digits: OTP_MIN_SECURE_DIGITS,
-      period: OTP_MIN_SECURE_PERIOD,
-      header: OTP_DEFAULT_HEADER,
-      window: 1,
-      secretMethod: 'fromUTF8',
-    };
-    return { ...defaults, ...config } as Required<IOtpModuleOptions>;
   }
 }

--- a/lib/otp.module.ts
+++ b/lib/otp.module.ts
@@ -27,7 +27,7 @@ export class OtpModule {
         },
         OtpService,
       ],
-      exports: [OtpService],
+      exports: [OTP_CONFIG_TOKEN, OtpService],
     };
   }
 
@@ -53,7 +53,7 @@ export class OtpModule {
         },
         OtpService,
       ],
-      exports: [OtpService],
+      exports: [OTP_CONFIG_TOKEN, OtpService],
     };
   }
 

--- a/lib/otp.module.ts
+++ b/lib/otp.module.ts
@@ -1,7 +1,15 @@
-import { DynamicModule, Module } from '@nestjs/common';
-import { OtpService } from './services/otp.service';
+import { DynamicModule, Logger, Module } from '@nestjs/common';
+import { OtpService } from './services';
 import { IOtpModuleAsyncOptions, IOtpModuleOptions } from './interfaces';
-import { OTP_CONFIG_TOKEN } from './otp.constants';
+import {
+  OTP_CONFIG_TOKEN,
+  OTP_DEFAULT_HEADER,
+  OTP_MAX_SECURE_PERIOD,
+  OTP_MIN_DIGITS,
+  OTP_MIN_PERIOD,
+  OTP_MIN_SECURE_DIGITS,
+  OTP_MIN_SECURE_PERIOD,
+} from './otp.constants';
 
 @Module({})
 export class OtpModule {
@@ -15,7 +23,7 @@ export class OtpModule {
       providers: [
         {
           provide: OTP_CONFIG_TOKEN,
-          useValue: opts,
+          useValue: OtpModule.resolveConfig(opts),
         },
         OtpService,
       ],
@@ -33,13 +41,87 @@ export class OtpModule {
       imports: options.imports,
       providers: [
         {
-          provide: OTP_CONFIG_TOKEN,
+          provide: `${OTP_CONFIG_TOKEN}_TEMP`,
           useFactory: options.useFactory,
           inject: options.inject,
+        },
+        {
+          provide: OTP_CONFIG_TOKEN,
+          useFactory: (configTemp: IOtpModuleOptions) =>
+            OtpModule.resolveConfig(configTemp),
+          inject: [`${OTP_CONFIG_TOKEN}_TEMP`],
         },
         OtpService,
       ],
       exports: [OtpService],
     };
+  }
+
+  private static resolveConfig(
+    config: IOtpModuleOptions,
+  ): Required<IOtpModuleOptions> {
+    return OtpModule.resolveConfig(OtpModule.validateOpts(config));
+  }
+
+  private static validateOpts(config: IOtpModuleOptions) {
+    const logger = new Logger(OtpModule.name);
+
+    if (!config.secretResolver) {
+      logger.warn(
+        'No secret resolver provided. Module will not work properly!',
+      );
+    }
+
+    if (!config.label) {
+      logger.warn('No label provided for OTP, defaulting to "OTP"');
+      config.label = 'OTP';
+    }
+
+    if (!config.issuer) {
+      logger.warn('No issuer provided for OTP, defaulting to "OTP"');
+      config.issuer = 'OTP';
+    }
+
+    if (config.digits !== undefined && config.digits <= OTP_MIN_DIGITS) {
+      logger.warn(
+        `Invalid digits provided for OTP ${config.digits}, defaulting to ${OTP_MIN_SECURE_DIGITS}`,
+      );
+      config.digits = OTP_MIN_SECURE_DIGITS;
+    } else if (config.digits < OTP_MIN_SECURE_DIGITS) {
+      logger.warn(
+        `Insecure number of digits provided for OTP (${config.digits})`,
+      );
+    }
+
+    if (config.period !== undefined && config.period <= OTP_MIN_PERIOD) {
+      logger.warn(
+        `Invalid period provided for OTP ${config.period}, defaulting to ${OTP_MIN_SECURE_PERIOD}`,
+      );
+      config.period = OTP_MIN_SECURE_PERIOD;
+    } else if (
+      config.period < OTP_MIN_SECURE_PERIOD ||
+      config.period > OTP_MAX_SECURE_PERIOD
+    ) {
+      logger.warn(
+        `Consider using a different period for OTP instead of ${config.period}`,
+      );
+    }
+
+    return config;
+  }
+
+  private static setDefaultOpts(
+    config: IOtpModuleOptions,
+  ): Required<IOtpModuleOptions> {
+    const defaults: Omit<IOtpModuleOptions, 'label' | 'issuer'> = {
+      issuerInLabel: false,
+      algorithm: 'SHA1',
+      digits: OTP_MIN_SECURE_DIGITS,
+      period: OTP_MIN_SECURE_PERIOD,
+      header: OTP_DEFAULT_HEADER,
+      window: 1,
+      secretMethod: 'fromUTF8',
+    };
+    return { ...defaults, ...config } as Required<IOtpModuleOptions>;
   }
 }

--- a/lib/otp.module.ts
+++ b/lib/otp.module.ts
@@ -60,7 +60,7 @@ export class OtpModule {
   private static resolveConfig(
     config: IOtpModuleOptions,
   ): Required<IOtpModuleOptions> {
-    return OtpModule.resolveConfig(OtpModule.validateOpts(config));
+    return OtpModule.setDefaultOpts(OtpModule.validateOpts(config));
   }
 
   private static validateOpts(config: IOtpModuleOptions) {
@@ -68,7 +68,7 @@ export class OtpModule {
 
     if (!config.secretResolver) {
       logger.warn(
-        'No secret resolver provided. Module will not work properly!',
+        'No secret resolver provided. Module might not work properly!',
       );
     }
 

--- a/lib/services/index.ts
+++ b/lib/services/index.ts
@@ -1,0 +1,1 @@
+export * from './otp.service';

--- a/lib/services/otp.service.ts
+++ b/lib/services/otp.service.ts
@@ -8,11 +8,9 @@ import * as QRCode from 'qrcode';
 export class OtpService {
   private readonly logger = new Logger(OtpService.name);
 
-  constructor(@Inject(OTP_CONFIG_TOKEN) private _config: IOtpModuleOptions) {}
-
-  get config(): Required<IOtpModuleOptions> {
-    return this._config as Required<IOtpModuleOptions>;
-  }
+  constructor(
+    @Inject(OTP_CONFIG_TOKEN) private config: Required<IOtpModuleOptions>,
+  ) {}
 
   /**
    * Generate a random secret for the OTP.

--- a/lib/services/otp.service.ts
+++ b/lib/services/otp.service.ts
@@ -14,8 +14,8 @@ import {
   OTP_MIN_PERIOD,
   OTP_MIN_SECURE_DIGITS,
   OTP_MIN_SECURE_PERIOD,
-} from './otp.constants';
-import { IOtpModuleOptions, IOtpPairOpts } from './interfaces';
+} from '../otp.constants';
+import { IOtpModuleOptions, IOtpPairOpts } from '../interfaces';
 import * as OTPAuth from 'otpauth';
 import * as QRCode from 'qrcode';
 
@@ -79,31 +79,6 @@ export class OtpService implements OnModuleInit {
       ...this.config,
       secret: OTPAuth.Secret[this.config.secretMethod](opts.secret),
     });
-  }
-
-  /**
-   * Verify an OTP token against a secret.
-   * @param token - The OTP token to verify.
-   * @param secret - The secret used to verify the token.
-   * @param shouldThrow - Whether to throw an exception if the token is invalid.
-   * @returns Whether the token is valid.
-   * @throws {UnauthorizedException} If the token is invalid and `shouldThrow` is true.
-   */
-  async verify(
-    token: string,
-    secret: string,
-    shouldThrow = true,
-  ): Promise<boolean> {
-    const otp = this.getTOTP({
-      secret,
-    });
-    const res = otp.validate({
-      token,
-    });
-    if (res === null && shouldThrow) {
-      throw new UnauthorizedException();
-    }
-    return res !== null;
   }
 
   /**

--- a/lib/services/otp.service.ts
+++ b/lib/services/otp.service.ts
@@ -20,18 +20,13 @@ import * as OTPAuth from 'otpauth';
 import * as QRCode from 'qrcode';
 
 @Injectable()
-export class OtpService implements OnModuleInit {
+export class OtpService {
   private readonly logger = new Logger(OtpService.name);
 
   constructor(@Inject(OTP_CONFIG_TOKEN) private _config: IOtpModuleOptions) {}
 
   get config(): Required<IOtpModuleOptions> {
     return this._config as Required<IOtpModuleOptions>;
-  }
-
-  onModuleInit() {
-    this.validateOpts();
-    this.setDefaultOpts();
   }
 
   /**
@@ -113,67 +108,5 @@ export class OtpService implements OnModuleInit {
         resolve(url);
       });
     });
-  }
-
-  private validateOpts() {
-    if (!this.config.secretResolver) {
-      this.logger.warn(
-        'No secret resolver provided. Module will not work properly!',
-      );
-    }
-
-    if (!this.config.label) {
-      this.logger.warn('No label provided for OTP, defaulting to "OTP"');
-      this.config.label = 'OTP';
-    }
-
-    if (!this.config.issuer) {
-      this.logger.warn('No issuer provided for OTP, defaulting to "OTP"');
-      this.config.issuer = 'OTP';
-    }
-
-    if (
-      this.config.digits !== undefined &&
-      this.config.digits <= OTP_MIN_DIGITS
-    ) {
-      this.logger.warn(
-        `Invalid digits provided for OTP ${this.config.digits}, defaulting to ${OTP_MIN_SECURE_DIGITS}`,
-      );
-      this.config.digits = OTP_MIN_SECURE_DIGITS;
-    } else if (this.config.digits < OTP_MIN_SECURE_DIGITS) {
-      this.logger.warn(
-        `Insecure number of digits provided for OTP (${this.config.digits})`,
-      );
-    }
-
-    if (
-      this.config.period !== undefined &&
-      this.config.period <= OTP_MIN_PERIOD
-    ) {
-      this.logger.warn(
-        `Invalid period provided for OTP ${this.config.period}, defaulting to ${OTP_MIN_SECURE_PERIOD}`,
-      );
-      this.config.period = OTP_MIN_SECURE_PERIOD;
-    } else if (
-      this.config.period < OTP_MIN_SECURE_PERIOD ||
-      this.config.period > OTP_MAX_SECURE_PERIOD
-    ) {
-      this.logger.warn(
-        `Consider using a different period for OTP instead of ${this.config.period}`,
-      );
-    }
-  }
-
-  private setDefaultOpts() {
-    const defaults: Omit<IOtpModuleOptions, 'label' | 'issuer'> = {
-      issuerInLabel: false,
-      algorithm: 'SHA1',
-      digits: OTP_MIN_SECURE_DIGITS,
-      period: OTP_MIN_SECURE_PERIOD,
-      header: OTP_DEFAULT_HEADER,
-      window: 1,
-      secretMethod: 'fromUTF8',
-    };
-    this._config = { ...defaults, ...this.config };
   }
 }

--- a/lib/services/otp.service.ts
+++ b/lib/services/otp.service.ts
@@ -1,20 +1,5 @@
-import {
-  Inject,
-  Injectable,
-  Logger,
-  OnModuleInit,
-  UnauthorizedException,
-} from '@nestjs/common';
-import {
-  OTP_CONFIG_TOKEN,
-  OTP_DEFAULT_HEADER,
-  OTP_DEFAULT_SECRET_LENGTH,
-  OTP_MAX_SECURE_PERIOD,
-  OTP_MIN_DIGITS,
-  OTP_MIN_PERIOD,
-  OTP_MIN_SECURE_DIGITS,
-  OTP_MIN_SECURE_PERIOD,
-} from '../otp.constants';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { OTP_CONFIG_TOKEN, OTP_DEFAULT_SECRET_LENGTH } from '../otp.constants';
 import { IOtpModuleOptions, IOtpPairOpts } from '../interfaces';
 import * as OTPAuth from 'otpauth';
 import * as QRCode from 'qrcode';

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "authentication module"
   ],
   "scripts": {
-    "build": "rimraf -rf dist && tsc -p tsconfig.json",
+    "build": "rimraf -rf dist && tsc -p tsconfig.build.json",
     "build:docs": "npx typedoc --out docs lib/index.ts --plugin typedoc-plugin-markdown",
     "dev": "tsc -w",
     "format": "prettier --write \"{lib}/**/*.ts\"",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "lib/__tests__"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
   },
   "include": ["lib/**/*"],
   "exclude": [
-    "node_modules",
-    "lib/__tests__"
+    "node_modules"
   ]
 }


### PR DESCRIPTION
# Verification moved to guard

`verify` is now a part of `OtpGuard` (moved from `OtpService`) in order to keep separation of concerns

# Validation of config

- validation of config is now a part of `OtpModule` registration
- same applies to setting default opts
- created `OtpConfigResolver` helper

# New flags in config

- `skipValidation` and `silent`

# Added tests

- tests for new features and structure